### PR TITLE
Ifc tiler

### DIFF
--- a/py3dtilers/IfcTiler/IfcTiler.py
+++ b/py3dtilers/IfcTiler/IfcTiler.py
@@ -18,12 +18,12 @@ def parse_command_line():
                         help='path to the ifc file')
     parser.add_argument('--originalUnit',
                         nargs='?',
-                        default="?",
+                        default="m",
                         type=str,
                         help='original unit of the ifc file')
     parser.add_argument('--targetedUnit',
                         nargs='?',
-                        default="?",
+                        default="m",
                         type=str,
                         help='targeted unit of the 3DTiles produced')
 


### PR DESCRIPTION
New type of extruded polygone handled : 
- IfcRectangleProfileDef
- IfcCircleProfileDef

For both of those methods, the points describing either the circle or the rectangle must be created.
Also the last one must be the first one, in order to have a closed polyline to extrud.

What is still missing : 
- Boolean between geometry
- Brep