### PR TITLE
GeojsonTiler can parse LineString and MultiLineString

### DIFF
--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -105,7 +105,6 @@ def main():
     properties = ['height', args.height, 'prec', args.prec]
 
     if(os.path.isdir(path) or Path(path).suffix == ".geojson" or Path(path).suffix == ".json"):
-        print("Reading " + path)
         tileset = from_geojson_directory(path, properties, args.obj, args.lod1, create_loa, args.loa, args.is_roof)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -43,7 +43,16 @@ def parse_command_line():
                         default='HAUTEUR',
                         type=str,
                         help='Change the name of the propertie to look for in the feature for height.\
+                              The value can be a float, this will set the default height.\
                               Default property name is HAUTEUR')
+
+    parser.add_argument('--width',
+                        nargs='?',
+                        default='LARGEUR',
+                        type=str,
+                        help='Change the name of the propertie to look for in the feature for width.\
+                              The value can be a float, this will set the default width.\
+                              Default property name is LARGEUR')
 
     parser.add_argument('--prec',
                         nargs='?',
@@ -102,7 +111,7 @@ def main():
 
     create_loa = args.loa is not None
 
-    properties = ['height', args.height, 'prec', args.prec]
+    properties = ['height', args.height, 'width', args.width, 'prec', args.prec]
 
     if(os.path.isdir(path) or Path(path).suffix == ".geojson" or Path(path).suffix == ".json"):
         tileset = from_geojson_directory(path, properties, args.obj, args.lod1, create_loa, args.loa, args.is_roof)

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -53,22 +53,24 @@ By default, the tiler considers that the polygons in the .geojson files are at t
 geojson-tiler --path <path> --is_roof
 ```
 ### Properties
-The Tiler uses '_height_' property to create 3D tiles from features. It also uses the '_prec_' property to check if the altitude is usable and skip features without altitude (when the altitude is missing, the _prec_ is equal to 9999, so we skip features with prec >= 9999).
+The Tiler uses '_height_' property to create 3D tiles from features. The '_width_' property will be used __only when parsing LineString or MultiLineString__ geometries. This width will define the size of the buffer applied to the lines.  
+The Tiler also uses the '_prec_' property to check if the altitude is usable and skip features without altitude (when the altitude is missing, the _prec_ is equal to 9999, so we skip features with prec >= 9999).
 
 By default, those properties are equal to:
 - 'prec' --> 'PREC_ALTI'
 - 'height' --> 'HAUTEUR'
+- 'width' --> 'LARGEUR'
 
-It means the tiler will target the property 'HAUTEUR' to find the height and 'PREC_ALTI' to find the altitude precision.
+It means the tiler will target the property 'HAUTEUR' to find the height, 'LARGEUR' to find the width and 'PREC_ALTI' to find the altitude precision.
 
-If the file don't have those properties, you can change one or several property names to target in command line with `--height` or `--prec`:
+If the file doesn't contain those properties, you can change one or several property names to target in command line with `--height`, `--width` or `--prec`:
 ```
-geojson-tiler --path <path> --height HEIGHT_NAME --prec PREC_NAME
+geojson-tiler --path <path> --height HEIGHT_NAME --width WIDTH_NAME --prec PREC_NAME
 ```
 
-You can set the height to a default value (used for all features). The height must be an _int_ or a _float_:
+You can set the height or the width to a default value (used for all features). The value must be an _int_ or a _float_:
 ```
-geojson-tiler --path <path> --height 10.5
+geojson-tiler --path <path> --height 10.5 --width 6.4
 ```
 
 If you want to skip the precision, you can set _prec_ to '_NONE_':

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -12,13 +12,21 @@ See https://github.com/VCityTeam/py3dtilers/blob/master/README.md
 
 ## Use the Tiler
 ### Files path
-To execute the GeojsonTiler, use the flag `--path` followed by the path of a folder containing .json or .geojson files
+To execute the GeojsonTiler, use the flag `--path` followed by the path of a geojson file or a folder containing geojson files
 
 Example:
+
+```bash
+geojson-tiler --path ../../geojsons/file.geojson
 ```
-geojson-tiler --path ../../geojson/
+
+It will read ___file.geojson___ and parse it into 3DTiles.
+
+```bash
+geojson-tiler --path ../../geojsons/
 ```
-It will read all .geojson and .json in the _geojson_ directory and parse them into 3DTiles.
+
+It will read all .geojson and .json in the ___geojsons___ directory and parse them into 3DTiles.
 
 ### LOA
 Using the LOA\* option creates a tileset with a __refinement hierarchy__. The leaves of the created tree are the detailed features (features loaded from the data source) and their parents are LOA geometries of those detailed features. The LOA geometries are 3D extrusions of polygons. The polygons must be given as a path to a directory containing geojson file(s) (the features in those geojsons must be Polygons or MultiPolygons). The polygons can for example be roads, boroughs, rivers or any other geographical partition.

--- a/py3dtilers/GeojsonTiler/geojson.py
+++ b/py3dtilers/GeojsonTiler/geojson.py
@@ -46,18 +46,18 @@ class Geojson(ObjectToTile):
         https://stackoverflow.com/questions/64463369/intersection-of-two-infinite-lines-specified-by-points
         Find the intersection between 2 lines, each line is defined by 2 points
         """
-        p1_start    = np.asarray(l1_start)
-        p1_end      = np.asarray(l1_end)
-        p2_start    = np.asarray(l2_start)
-        p2_end      = np.asarray(l2_end)
+        p1_start = np.asarray(l1_start)
+        p1_end = np.asarray(l1_end)
+        p2_start = np.asarray(l2_start)
+        p2_end = np.asarray(l2_end)
 
-        p       = p1_start
-        r       = (p1_end-p1_start)
-        q       = p2_start
-        s       = (p2_end-p2_start)
+        p = p1_start
+        r = (p1_end - p1_start)
+        q = p2_start
+        s = (p2_end - p2_start)
 
-        t       = np.cross(q - p,s)/(np.cross(r,s))
-        i       = p + t*r
+        t = np.cross(q - p, s) / (np.cross(r, s))
+        i = p + t * r
         return i.tolist()
 
     def get_parallel_offset(self, start_point, end_point, offset=3):

--- a/tests/geojson_tiler_test_data/roads/line_string_road.geojson
+++ b/tests/geojson_tiler_test_data/roads/line_string_road.geojson
@@ -1,0 +1,12 @@
+{
+"__comment": "Made with QGIS from IGN open data. The data can be downloaded here https://geoservices.ign.fr/ressource/159380",
+"type": "FeatureCollection",
+"name": "line_string_road",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3946" } },
+"features": [
+{ "type": "Feature", "properties": { "ID": "TRONROUT0000002204326596", "IMPORTANCE": "5", "POS_SOL": "0", "PREC_ALTI": 1.5, "NB_VOIES": 2, "LARGEUR": 6.0 }, "geometry": { "type": "LineString", "coordinates": 
+[
+[ 1844018.614547449396923, 5175368.074526521377265, 167.2 ],
+[ 1844014.41793160745874, 5175401.201409922912717, 167.0 ] ] } }
+]
+}

--- a/tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson
+++ b/tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson
@@ -1,0 +1,9 @@
+{
+"__comment": "Made with QGIS from IGN open data. The data can be downloaded here https://geoservices.ign.fr/ressource/159380",
+"type": "FeatureCollection",
+"name": "multi_line_string_road",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3946" } },
+"features": [
+{ "type": "Feature", "properties": { "ID": "TRONROUT0000002204326596", "IMPORTANCE": "5", "POS_SOL": "0", "PREC_ALTI": 1.5, "NB_VOIES": 2, "LARGEUR": 6.0 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 1844029.513947007246315, 5175322.636617271229625, 167.4 ], [ 1844025.813421350205317, 5175334.446645244956017, 167.3 ], [ 1844021.113099121721461, 5175351.160729296505451, 167.2 ], [ 1844018.614547449396923, 5175368.074526521377265, 167.2 ], [ 1844014.41793160745874, 5175401.201409922912717, 167.0 ] ] ] } }
+]
+}

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -17,7 +17,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, obj_name)
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "basic_case"
@@ -34,7 +34,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, obj_name)
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "properties_with_other_name"
@@ -51,7 +51,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, obj_name)
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "default_height"
@@ -68,7 +68,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, obj_name)
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "no_height"
@@ -84,7 +84,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, create_loa=True, polygons_path='tests/geojson_tiler_test_data/polygons/')
+        tileset = from_geojson_directory(path, properties, create_loa=True, polygons_path='tests/geojson_tiler_test_data/polygons/', is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "create_loa"
@@ -100,7 +100,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, create_lod1=True)
+        tileset = from_geojson_directory(path, properties, create_lod1=True, is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "create_lod1"
@@ -116,7 +116,7 @@ class Test_Tile(unittest.TestCase):
         if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
             os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
 
-        tileset = from_geojson_directory(path, properties, create_lod1=True, create_loa=True, polygons_path='tests/geojson_tiler_test_data/polygons/')
+        tileset = from_geojson_directory(path, properties, create_lod1=True, create_loa=True, polygons_path='tests/geojson_tiler_test_data/polygons/', is_roof=True)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             folder_name = "create_lod1"

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -126,7 +126,7 @@ class Test_Tile(unittest.TestCase):
     def test_line_string(self):
         path = 'tests/geojson_tiler_test_data/roads/line_string_road.geojson'
         obj_name = 'tests/geojson_tiler_test_data/generated_objs/road_line_string.obj'
-        properties = ['height', '1', 'prec', 'NONE']
+        properties = ['height', '1', 'width', '1', 'prec', 'NONE']
 
         if not os.path.exists('tests/geojson_tiler_test_data/generated_objs'):
             os.makedirs('tests/geojson_tiler_test_data/generated_objs')
@@ -143,7 +143,7 @@ class Test_Tile(unittest.TestCase):
     def test_multi_line_string(self):
         path = 'tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson'
         obj_name = 'tests/geojson_tiler_test_data/generated_objs/road_multi_line_string.obj'
-        properties = ['height', '1', 'prec', 'NONE']
+        properties = ['height', '1', 'width', '1', 'prec', 'NONE']
 
         if not os.path.exists('tests/geojson_tiler_test_data/generated_objs'):
             os.makedirs('tests/geojson_tiler_test_data/generated_objs')

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -123,6 +123,38 @@ class Test_Tile(unittest.TestCase):
             print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
             tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
 
+    def test_line_string(self):
+        path = 'tests/geojson_tiler_test_data/roads/line_string_road.geojson'
+        obj_name = 'tests/geojson_tiler_test_data/generated_objs/road_line_string.obj'
+        properties = ['height', '1', 'prec', 'NONE']
 
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_objs'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_objs')
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
+
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=False)
+        if(tileset is not None):
+            tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
+            folder_name = "line_string"
+            print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+            tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+
+    def test_multi_line_string(self):
+        path = 'tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson'
+        obj_name = 'tests/geojson_tiler_test_data/generated_objs/road_multi_line_string.obj'
+        properties = ['height', '1', 'prec', 'NONE']
+
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_objs'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_objs')
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
+
+        tileset = from_geojson_directory(path, properties, obj_name, is_roof=False)
+        if(tileset is not None):
+            tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
+            folder_name = "multi_line_string"
+            print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+            tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -156,5 +156,7 @@ class Test_Tile(unittest.TestCase):
             folder_name = "multi_line_string"
             print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
             tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
GeojsonTiler can create 3DTiles from LineString and MultiLineString by buffering those lines into polygons.

This PR implements:

* Line buffering
* Custom triangulation method for buffered lines
* Width as argument to use an arbitrary offset value when buffering lines
* Tests for LineString and MultiLineStrings
* Doc update