### PR TITLE
CityTiler and CityTemporalTiler use the same config path

### DIFF
--- a/py3dtilers/CityTiler/CityTemporalTiler.py
+++ b/py3dtilers/CityTiler/CityTemporalTiler.py
@@ -22,11 +22,6 @@ class CityTemporalTiler(CityTiler):
     def __init__(self):
         super().__init__()
 
-        self.parser.add_argument('--db_config_path',
-                                 nargs='+',
-                                 default='CityTilerDBConfig.yml',
-                                 type=str,
-                                 help='Path(es) to the database configuration file(s)')
         self.parser.add_argument('--time_stamps',
                                  nargs='+',
                                  type=str,

--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -18,11 +18,11 @@ class CityTiler(Tiler):
         super().__init__()
 
         # adding positional arguments
-        self.parser.add_argument('db_config_path',
-                                 nargs='?',
+        self.parser.add_argument('--db_config_path',
+                                 nargs='*',
                                  default='py3dtilers/CityTiler/CityTilerDBConfig.yml',
-                                 type=str,  # why precise this if it is the default config ?
-                                 help='path to the database configuration file')
+                                 type=str,
+                                 help='Path(es) to the database configuration file(s)')
 
         self.parser.add_argument('object_type',
                                  nargs='?',
@@ -159,7 +159,7 @@ def main():
     city_tiler.parse_command_line()
     args = city_tiler.args
 
-    cursor = open_data_base(args.db_config_path)
+    cursor = open_data_base(args.db_config_path[0])
 
     if args.object_type == "building":
         objects_type = CityMBuildings

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -16,7 +16,7 @@ Copy and customize the [CityTilerDBConfigReference.yml](CityTilerDBConfigReferen
 
 You can then run the tiler by specifying the path to the _.yml_ configuration file:  
 ```
-citygml-tiler <path_to_file>/Config.yml
+citygml-tiler --db_config_path <path_to_file>/Config.yml
 ```
 
 The created tileset will be placed in a folder named `junk_<objects-type>` in the root directory. The name of the folder will be either `junk_buildings`, `junk_reliefs`, `junk_water_bodies` or `junk_bridges`, depending on the [objects type](#objects-type) (respectively `building`, `relief`, `water` and `bridge`).
@@ -31,19 +31,19 @@ By default, the tiler will treat the data as __buildings__. You can change the t
 
 * `building`
 ```
-citygml-tiler <path_to_file>/Config.yml building
+citygml-tiler --db_config_path <path_to_file>/Config.yml building
 ```
 * `relief`
 ```
-citygml-tiler <path_to_file>/Config.yml relief
+citygml-tiler --db_config_path <path_to_file>/Config.yml relief
 ```
 * `water`
 ```
-citygml-tiler <path_to_file>/Config.yml water
+citygml-tiler --db_config_path <path_to_file>/Config.yml water
 ```
 * `bridge`
 ```
-citygml-tiler <path_to_file>/Config.yml bridge
+citygml-tiler --db_config_path <path_to_file>/Config.yml bridge
 ```
 
 ### LOA
@@ -51,7 +51,7 @@ Using the LOA\* option creates a tileset with a __refinement hierarchy__. The le
 
 To use the LOA option:
 ```
-citygml-tiler <path_to_file>/Config.yml --loa <path-to-polygons>
+citygml-tiler --db_config_path <path_to_file>/Config.yml --loa <path-to-polygons>
 ```
 
 \*_LOA (Level Of Abstraction): here, it is simple 3D extrusion of a polygon._
@@ -61,7 +61,7 @@ Using the LOD1 option creates a tileset with a __refinement hierarchy__. The lea
 
 To use the LOD1 option:
 ```
-citygml-tiler <path_to_file>/Config.yml --lod1
+citygml-tiler --db_config_path <path_to_file>/Config.yml --lod1
 ```
 
 ### Textures
@@ -69,7 +69,7 @@ By default, the objects are created without their texture.
 
 To add texture:
 ```
-citygml-tiler <path_to_file>/Config.yml --with_texture
+citygml-tiler --db_config_path <path_to_file>/Config.yml --with_texture
 ```
 
 ### Split surfaces
@@ -77,14 +77,14 @@ By default, the tiler merges the surfaces of the same CityObject into one geomet
 
 To keep the surfaces split:
 ```
-citygml-tiler <path_to_file>/Config.yml --split_surfaces
+citygml-tiler --db_config_path <path_to_file>/Config.yml --split_surfaces
 ```
 ### Batch Table Hierarchy
 The Batch table hierarchy is a [Batch Table](https://github.com/CesiumGS/3d-tiles/blob/main/specification/TileFormats/BatchTable/README.md) extension. This extension creates a link between the buildings and their surfaces.
 
 To create the BatchTableHierarchy extension:
 ```
-citygml-tiler <path_to_file>/Config.yml --with_BTH
+citygml-tiler --db_config_path <path_to_file>/Config.yml --with_BTH
 ```
 
 # City Temporal Tiler


### PR DESCRIPTION
CityTiler and CityTemporalTiler now use the same `--db_config_path` flag. This avoids conflicts between `db_config_path` from the CityTiler and `--db_config_path` from the CityTemporalTiler. See [issue](https://github.com/VCityTeam/py3dtilers/issues/30)