### PR TITLE
Materials in ObjectsToTile & color with GeoJsonTiler

### DIFF
--- a/py3dtilers/Common/group.py
+++ b/py3dtilers/Common/group.py
@@ -28,6 +28,11 @@ class Group():
         return rounded_coord
 
     def add_materials(self, materials):
+        """
+        Keep only the materials used by the objects of this group,
+        among all the materials created, and add them to the geometries.
+        :param materials: an array of all the materials
+        """
         seen_mat_indexes = dict()
         group_materials = []
         for feature in self.objects_to_tile:
@@ -66,6 +71,10 @@ class Groups():
         return self.groups
 
     def set_materials(self, materials):
+        """
+        Set the materials of each group.
+        :param materials: an array of all the materials
+        """
         for group in self.groups:
             group.add_materials(materials)
 

--- a/py3dtilers/Common/group.py
+++ b/py3dtilers/Common/group.py
@@ -27,6 +27,17 @@ class Group():
             rounded_coord[i] = base * round(coordinates[i] / base)
         return rounded_coord
 
+    def add_materials(self, materials):
+        seen_mat_indexes = dict()
+        group_materials = []
+        for feature in self.objects_to_tile:
+            mat_index = feature.material_index
+            if mat_index not in seen_mat_indexes:
+                seen_mat_indexes[mat_index] = len(group_materials)
+                group_materials.append(materials[mat_index])
+            feature.material_index = seen_mat_indexes[mat_index]
+        self.objects_to_tile.set_materials(group_materials)
+
 
 class Groups():
     """
@@ -42,15 +53,21 @@ class Groups():
         When this param is not None, it means we want to group geometries by polygons
         """
         self.objects_to_tile = objects_to_tile
+        self.materials = objects_to_tile.materials
         if objects_to_tile.is_list_of_objects_to_tile():
             self.group_objects_by_instance()
         elif polygons_path is not None:
             self.group_objects_by_polygons(polygons_path)
         else:
             self.group_objects_with_kdtree()
+        self.set_materials(self.materials)
 
     def get_groups_as_list(self):
         return self.groups
+
+    def set_materials(self, materials):
+        for group in self.groups:
+            group.add_materials(materials)
 
     def group_objects_by_instance(self):
         groups = list()

--- a/py3dtilers/Common/object_to_tile.py
+++ b/py3dtilers/Common/object_to_tile.py
@@ -129,11 +129,11 @@ class ObjectsToTile(object):
         return len(self.objects)
 
     def is_list_of_objects_to_tile(self):
-        '''Check if this instance of ObjectsToTile contains others ObjectsToTile'''
+        """Check if this instance of ObjectsToTile contains others ObjectsToTile"""
         return isinstance(self.objects[0], ObjectsToTile)
 
     def get_size(self):
-        '''Recursive method to get the length'''
+        """Recursive method to get the length"""
         return sum([obj.get_size() for obj in self])
 
     def get_centroid(self):
@@ -153,23 +153,29 @@ class ObjectsToTile(object):
 
     def set_materials(self, materials):
         """
+        Set the materials of this object to a new array of materials.
         :param materials: an array of GlTFMaterial
         """
         self.materials = materials
 
     def add_materials(self, materials):
         """
+        Extend the materials of this object with another array of materials.
         :param materials: an array of GlTFMaterial
         """
         self.materials.extend(materials)
 
     def get_material(self, index):
+        """
+        Get the material at the index.
+        :param index: the index (int) of the material
+        """
         return self.materials[index]
 
     def translate_objects(self, offset):
         """
-        :param offset: an offset
-        :return:
+        Translate the geometries by substracting an offset
+        :param offset: the Vec3 translation offset
         """
         # Translate the position of each object by an offset
         for object_to_tile in self.get_objects():
@@ -186,8 +192,8 @@ class ObjectsToTile(object):
 
     def change_crs(self, transformer):
         """
+        Project the geometries into another CRS
         :param transformer: the transformer used to change the crs
-        :return:
         """
         for object_to_tile in self.get_objects():
             new_geom = []
@@ -202,8 +208,8 @@ class ObjectsToTile(object):
 
     def scale_objects(self, scale_factor):
         """
-        :param transformer: the transformer used to change the crs
-        :return:
+        Rescale the geometries.
+        :param scale_factor: the factor to scale the objects
         """
         centroid = self.get_centroid()
         for object_to_tile in self.get_objects():

--- a/py3dtilers/Common/object_to_tile.py
+++ b/py3dtilers/Common/object_to_tile.py
@@ -1,5 +1,5 @@
 import numpy as np
-from py3dtiles import BoundingVolumeBox, TriangleSoup
+from py3dtiles import BoundingVolumeBox, TriangleSoup, GlTFMaterial
 
 
 class ObjectToTile(object):
@@ -25,6 +25,8 @@ class ObjectToTile(object):
         self.centroid = np.array([0, 0, 0])
 
         self.texture = None
+
+        self.material_index = 0
 
         self.set_id(id)
 
@@ -88,6 +90,7 @@ class ObjectsToTile(object):
 
     def __init__(self, objects=None):
         self.objects = list()
+        self.materials = [GlTFMaterial()]
         if(objects):
             self.objects.extend(objects)
 
@@ -147,6 +150,21 @@ class ObjectsToTile(object):
         return np.array([centroid[0] / self.get_size(),
                          centroid[1] / self.get_size(),
                          centroid[2] / self.get_size()])
+
+    def set_materials(self, materials):
+        """
+        :param materials: an array of GlTFMaterial
+        """
+        self.materials = materials
+
+    def add_materials(self, materials):
+        """
+        :param materials: an array of GlTFMaterial
+        """
+        self.materials.extend(materials)
+
+    def get_material(self, index):
+        return self.materials[index]
 
     def translate_objects(self, offset):
         """

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -1,13 +1,8 @@
 import numpy as np
-import random
 from py3dtiles import B3dm, BatchTable, BoundingVolumeBox, GlTF, GlTFMaterial
 from py3dtiles import Tile, TileSet
 from ..Common import LodTree
 from ..Texture import Atlas
-
-
-def get_random_color():
-    return [round(random.random(), 2) for i in range(0, 3)]
 
 
 def create_tileset(objects_to_tile, create_lod1=False, create_loa=False, polygons_path=None, extension_name=None, with_texture=False):
@@ -71,24 +66,23 @@ def create_tile_content(objects, extension_name=None, with_texture=False):
     # create B3DM content
     arrays = []
     materials = []
-    mat_index = 0
+    seen_mat_indexes = []
     if with_texture:
         tile_atlas = Atlas(objects)
+        objects.set_materials([GlTFMaterial(textureUri='./ATLAS_' + str(tile_atlas.tile_number) + '.png')])
     for feature in objects:
+        mat_index = feature.material_index
+        if mat_index not in seen_mat_indexes:
+            seen_mat_indexes.append(mat_index)
+            materials.append(objects.get_material(mat_index))
         content = {
             'position': feature.geom.getPositionArray(),
             'normal': feature.geom.getNormalArray(),
             'bbox': [[float(i) for i in j] for j in feature.geom.getBbox()],
             'matIndex': mat_index
         }
-        # print(get_random_color())
-        mat = GlTFMaterial(rgb=get_random_color())
-        # mat = GlTFMaterial(rgb=[1,1,0])
         if with_texture:
             content['uv'] = feature.geom.getDataArray(0)
-            mat.textureUri = './ATLAS_' + str(tile_atlas.tile_number) + '.png'
-        mat_index += 1
-        materials.append(mat)
         arrays.append(content)
 
     # GlTF uses a y-up coordinate system whereas the geographical data (stored
@@ -105,7 +99,8 @@ def create_tile_content(objects, extension_name=None, with_texture=False):
                           0, 1, 0, 0,
                           0, 0, 0, 1])
 
-    gltf = GlTF.from_binary_arrays(arrays, transform, splitted=True, materials=materials)
+    batched = len(materials) <= 1
+    gltf = GlTF.from_binary_arrays(arrays, transform, batched=batched, materials=materials)
 
     # Create a batch table and add the ID of each feature to it
     ids = [feature.get_id() for feature in objects]

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -105,7 +105,7 @@ def create_tile_content(objects, extension_name=None, with_texture=False):
                           0, 1, 0, 0,
                           0, 0, 0, 1])
 
-    gltf = GlTF.from_binary_arrays(arrays, transform, materials=materials)
+    gltf = GlTF.from_binary_arrays(arrays, transform, splitted=True, materials=materials)
 
     # Create a batch table and add the ID of each feature to it
     ids = [feature.get_id() for feature in objects]

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -4,8 +4,8 @@ from os import listdir
 import json
 
 from pathlib import Path
-from py3dtiles import BoundingVolumeBox
-from .geojson import Geojsons
+from py3dtiles import BoundingVolumeBox, GlTFMaterial
+from .geojson import Geojson, Geojsons
 from .geojson_line import GeojsonLine
 from .geojson_polygon import GeojsonPolygon
 from ..Common import Tiler
@@ -50,6 +50,11 @@ class GeojsonTiler(Tiler):
                                  action='store_true',
                                  help='When defined, the features from geojsons will be considered as rooftops.\
                                     We will thus substract the height from the coordinates to reach the floor.')
+
+        self.parser.add_argument('--add_color',
+                                 dest='add_color',
+                                 action='store_true',
+                                 help='When defined, add colors to the features depending on their height.')
 
     def parse_command_line(self):
         super().parse_command_line()
@@ -99,7 +104,20 @@ class GeojsonTiler(Tiler):
 
         return features
 
-    def from_geojson_directory(self, path, properties, is_roof=False):
+    def add_colors(self, objects_to_tile):
+        max_height = Geojson.max_height
+        min_height = Geojson.min_height
+        colors = []
+
+        for i in range(0, 10, 1):
+            colors.append(GlTFMaterial(rgb=[i / 10, (10 - i) / 10, 0]))
+        objects_to_tile.add_materials(colors)
+        for feature in objects_to_tile:
+            height_factor = (feature.height - min_height) / (max_height - min_height)
+            height_factor = round(height_factor * (len(colors) - 1)) + 1
+            feature.material_index = height_factor
+
+    def from_geojson_directory(self, path, properties, is_roof=False, add_color=False):
         """
         :param path: a path to a directory
 
@@ -108,6 +126,9 @@ class GeojsonTiler(Tiler):
 
         features = self.retrieve_geojsons(path)
         objects = Geojsons.parse_geojsons(features, properties, is_roof)
+
+        if add_color:
+            self.add_colors(objects)
 
         if(len(objects) == 0):
             print("No .geojson found in " + path)
@@ -132,7 +153,7 @@ def main():
     properties = ['height', geojson_tiler.args.height, 'width', geojson_tiler.args.width, 'prec', geojson_tiler.args.prec]
 
     if(os.path.isdir(path) or Path(path).suffix == ".geojson" or Path(path).suffix == ".json"):
-        tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof)
+        tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color)
         if(tileset is not None):
             tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
             print("tileset in geojson_tilesets")

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -105,6 +105,12 @@ class GeojsonTiler(Tiler):
         return features
 
     def add_colors(self, objects_to_tile):
+        """
+        Assigne a single-colored material to each feature.
+        The color depends on the height of the feature.
+        The taller the feature, the more the color tends towards red.
+        :param objects_to_tile: An instance of ObjectsToTile containing geometries
+        """
         max_height = Geojson.max_height
         min_height = Geojson.min_height
         colors = []
@@ -112,7 +118,7 @@ class GeojsonTiler(Tiler):
         for i in range(0, 10, 1):
             colors.append(GlTFMaterial(rgb=[i / 10, (10 - i) / 10, 0]))
         objects_to_tile.add_materials(colors)
-        for feature in objects_to_tile:
+        for feature in objects_to_tile.get_objects():
             height_factor = (feature.height - min_height) / (max_height - min_height)
             height_factor = round(height_factor * (len(colors) - 1)) + 1
             feature.material_index = height_factor

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -41,6 +41,14 @@ By default, the tiler considers that the polygons in the .geojson files are at t
 geojson-tiler --path <path> --is_roof
 ```
 
+### Color
+
+When present, the `--add_color` add a single colored material to each feature. The color of the material is determined by the height of the feature: the taller the feature, the more the color tends towards red.
+
+```bash
+geojson-tiler --path <path> --add_color
+```
+
 ### Properties
 
 The Tiler uses '_height_' property to create 3D tiles from features. The '_width_' property will be used __only when parsing LineString or MultiLineString__ geometries. This width will define the size of the buffer applied to the lines.  

--- a/py3dtilers/GeojsonTiler/geojson.py
+++ b/py3dtilers/GeojsonTiler/geojson.py
@@ -19,6 +19,9 @@ class Geojson(ObjectToTile):
     # Default height will be used if no height is found when parsing the data
     default_height = 2
 
+    max_height = np.NINF
+    min_height = np.Inf
+
     def __init__(self, id=None, feature_properties=None, feature_geometry=None):
         super().__init__(id)
 
@@ -62,6 +65,10 @@ class Geojson(ObjectToTile):
             if height_name in self.feature_properties:
                 if self.feature_properties[height_name] > 0:
                     self.height = self.feature_properties[height_name]
+                    if self.height > Geojson.max_height:
+                        Geojson.max_height = self.height
+                    if self.height < Geojson.min_height:
+                        Geojson.min_height = self.height
                 else:
                     self.height = Geojson.default_height
             else:

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -84,6 +84,25 @@ class Test_Tile(unittest.TestCase):
             print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
             tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
 
+    def test_add_color(self):
+        path = 'tests/geojson_tiler_test_data/buildings/feature_1/'
+        obj_name = 'tests/geojson_tiler_test_data/generated_objs/block_color.obj'
+        properties = ['height', 'HAUTEUR', 'prec', 'NONE']
+
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_objs'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_objs')
+        if not os.path.exists('tests/geojson_tiler_test_data/generated_tilesets'):
+            os.makedirs('tests/geojson_tiler_test_data/generated_tilesets')
+
+        geojson_tiler = GeojsonTiler()
+        geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False)
+        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True, add_color=True)
+        if(tileset is not None):
+            tileset.get_root_tile().set_bounding_volume(BoundingVolumeBox())
+            folder_name = "add_color"
+            print("tileset in tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+            tileset.write_to_directory("tests/geojson_tiler_test_data/generated_tilesets/" + folder_name)
+
     def test_create_loa(self):
         path = 'tests/geojson_tiler_test_data/buildings/feature_1/'
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI']


### PR DESCRIPTION
Store materials in ObjectsToTile. The materials are written into the GlTF during tileset creation.

Create a new flag `--add_color` for the GeojsonTiler. This flag add colors to the features depending on their height (lerp between green and red)
![image](https://user-images.githubusercontent.com/32875283/148222355-97af0b58-d9d0-4bf8-a6aa-1067afc0b6b0.png)
