### PR TITLE
Optimize texture memory in CityTiler 

### DIFF
--- a/py3dtilers/CityTiler/citym_bridge.py
+++ b/py3dtilers/CityTiler/citym_bridge.py
@@ -8,14 +8,17 @@ class CityMBridge(CityMCityObject):
     Implementation of the Bridge Model objects from the CityGML model.
     """
 
-    def __init__(self, id=None):
-        super().__init__(id)
+    def __init__(self, database_id=None, gml_id=None):
+        super().__init__(database_id, gml_id)
+        self.objects_type = CityMBridges
 
 
 class CityMBridges(CityMCityObjects):
     """
     A decorated list of CityMBridge type objects.
     """
+
+    object_type = CityMBridge
 
     def __init__(self, objects=None):
         super().__init__(objects)

--- a/py3dtilers/CityTiler/citym_building.py
+++ b/py3dtilers/CityTiler/citym_building.py
@@ -25,14 +25,18 @@ class CityMBuilding(CityMCityObject):
     Implementation of the Building Model objects from the CityGML model.
     """
 
-    def __init__(self, id=None):
-        super().__init__(id)
+    def __init__(self, database_id=None, gml_id=None):
+        super().__init__(database_id, gml_id)
+        self.objects_type = CityMBuildings
 
 
 class CityMBuildings(CityMCityObjects):
     """
     A decorated list of CityMBuilding type objects.
     """
+
+    object_type = CityMBuilding
+
     # with_bth value is set to False by default. the value of this variable
     # depends on the command line optional argument "--With_BTH" of CityTiler.
     with_bth = False

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -3,6 +3,7 @@ import sys
 from io import BytesIO
 
 from ..Common import ObjectToTile, ObjectsToTile
+from ..Texture import Texture
 
 
 class CityMCityObject(ObjectToTile):
@@ -14,6 +15,7 @@ class CityMCityObject(ObjectToTile):
     def __init__(self, database_id=None, gml_id=None):
         super().__init__(database_id)
         self.set_gml_id(gml_id)
+        self.texture_uri = None
 
     def get_database_id(self):
         return super().get_id()
@@ -34,11 +36,18 @@ class CityMCityObject(ObjectToTile):
         """
         return super().get_batchtable_data()['gml_id']
 
+    def get_texture(self):
+        stream = self.objects_type.get_image_from_binary(self.texture_uri, self.objects_type, CityMCityObjects.gml_cursor)
+        texture = Texture(stream, self.geom.triangles[1])
+        return texture.get_texture_image()
+
 
 class CityMCityObjects(ObjectsToTile):
     """
     A decorated list of CityMCityObject type objects.
     """
+
+    object_type = CityMCityObject
 
     gml_cursor = None
 
@@ -86,6 +95,7 @@ class CityMCityObjects(ObjectsToTile):
 
         if no_input:
             result_objects = objects_type()
+            object_type = objects_type.object_type
         else:
             # We need to deal with the fact that the answer will (generically)
             # not preserve the order of the objects that was given to the query
@@ -105,7 +115,7 @@ class CityMCityObjects(ObjectsToTile):
                 sys.exit(1)
             gml_id = t[2]
             if no_input:
-                new_object = CityMCityObject(object_id, gml_id)
+                new_object = object_type(object_id, gml_id)
                 result_objects.append(new_object)
             else:
                 cityobject = objects_with_gmlid_key[gml_id]

--- a/py3dtilers/CityTiler/citym_relief.py
+++ b/py3dtilers/CityTiler/citym_relief.py
@@ -23,14 +23,17 @@ class CityMRelief(CityMCityObject):
     Implementation of the Digital Terrain Model (DTM) objects from the CityGML model.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, database_id=None, gml_id=None):
+        super().__init__(database_id, gml_id)
+        self.objects_type = CityMReliefs
 
 
 class CityMReliefs(CityMCityObjects):
     """
     A decorated list of CityMRelief type objects.
     """
+
+    object_type = CityMRelief
 
     def __init__(self, objects=None):
         super().__init__(objects)

--- a/py3dtilers/CityTiler/citym_waterbody.py
+++ b/py3dtilers/CityTiler/citym_waterbody.py
@@ -23,14 +23,17 @@ class CityMWaterBody(CityMCityObject):
     Implementation of the Water Body Model objects from the CityGML model.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, database_id=None, gml_id=None):
+        super().__init__(database_id, gml_id)
+        self.objects_type = CityMWaterBodies
 
 
 class CityMWaterBodies(CityMCityObjects):
     """
     A decorated list of CityMWaterBody type objects.
     """
+
+    object_type = CityMWaterBody
 
     def __init__(self, objects=None):
         super().__init__(objects)


### PR DESCRIPTION
CityTiler used to load all texture images during [the geometry creation](https://github.com/VCityTeam/py3dtilers/blob/master/py3dtilers/CityTiler/CityTiler.py#L89) (images of the __whole tileset__ were loaded in memory). The Tiler memory usage was going up to __9 Go__ (28% of 32 Go RAM) for Lyon 1st borough.

With this PR, the textures are loaded tile by tile during the [atlas creation](https://github.com/VCityTeam/py3dtilers/blob/master/py3dtilers/Texture/atlas.py#L17). This way, the Tiler memory usage only goes up to __0,65 GO__ (0,5 GO on average) for the same borough.

The computation time stay the same.

