### PR TITLE
Textures for relief/bridges/waterbodies in CityTiler

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -23,7 +23,7 @@ class CityTiler(Tiler):
                                  type=str,
                                  help='Path(es) to the database configuration file(s)')
 
-        self.parser.add_argument('object_type',
+        self.parser.add_argument('--type',
                                  nargs='?',
                                  default='building',
                                  type=str,
@@ -163,18 +163,18 @@ def main():
 
     cursor = open_data_base(args.db_config_path[0])
 
-    if args.object_type == "building":
+    if args.type == "building":
         objects_type = CityMBuildings
         city_tiler.create_directory('junk_buildings')
         if args.with_BTH:
             CityMBuildings.set_bth()
-    elif args.object_type == "relief":
+    elif args.type == "relief":
         city_tiler.create_directory('junk_reliefs')
         objects_type = CityMReliefs
-    elif args.object_type == "water":
+    elif args.type == "water":
         city_tiler.create_directory('junk_water_bodies')
         objects_type = CityMWaterBodies
-    elif args.object_type == "bridge":
+    elif args.type == "bridge":
         city_tiler.create_directory('junk_bridges')
         objects_type = CityMBridges
 
@@ -196,13 +196,13 @@ def main():
     tileset.add_asset_extras(origin)
 
     cursor.close()
-    if args.object_type == "building":
+    if args.type == "building":
         tileset.write_to_directory('junk_buildings')
-    elif args.object_type == "relief":
+    elif args.type == "relief":
         tileset.write_to_directory('junk_reliefs')
-    elif args.object_type == "water":
+    elif args.type == "water":
         tileset.write_to_directory('junk_water_bodies')
-    elif args.object_type == "bridge":
+    elif args.type == "bridge":
         tileset.write_to_directory('junk_bridges')
 
 

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -33,30 +33,30 @@ The output folder contains:
 
 ### Objects type
 
-By default, the tiler will treat the data as __buildings__. You can change the type by adding one the 3 keywords:
+By default, the tiler will treat the data as __buildings__. You can change the type by adding the flag `--type` followed by one the 4 keywords:
 
 * `building`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml building
+citygml-tiler --db_config_path <path_to_file>/Config.yml --type building
 ```
 
 * `relief`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml relief
+citygml-tiler --db_config_path <path_to_file>/Config.yml --type relief
 ```
 
 * `water`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml water
+citygml-tiler --db_config_path <path_to_file>/Config.yml --type water
 ```
 
 * `bridge`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml bridge
+citygml-tiler --db_config_path <path_to_file>/Config.yml --type bridge
 ```
 
 ### Split surfaces

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -181,3 +181,23 @@ class CityMCityObjects(ObjectsToTile):
         LEFT_THUMB = imageBinaryData[0][0]
         stream = BytesIO(LEFT_THUMB)
         return stream
+
+    @staticmethod
+    def sql_query_centroid():
+        """
+        Virtual method: all CityMCityObjects and childs classes instances should
+        implement this method.
+
+        :return: no return value.
+        """
+        pass
+
+    @staticmethod
+    def sql_query_geometries_with_texture_coordinates():
+        """
+        Virtual method: all CityMCityObjects and childs classes instances should
+        implement this method.
+
+        :return: no return value.
+        """
+        pass

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -36,11 +36,6 @@ class CityMCityObject(ObjectToTile):
         """
         return super().get_batchtable_data()['gml_id']
 
-    def get_texture(self):
-        stream = self.objects_type.get_image_from_binary(self.texture_uri, self.objects_type, CityMCityObjects.gml_cursor)
-        texture = Texture(stream, self.geom.triangles[1])
-        return texture.get_texture_image()
-
 
 class CityMCityObjects(ObjectsToTile):
     """
@@ -53,6 +48,21 @@ class CityMCityObjects(ObjectsToTile):
 
     def __init__(self, cityMCityObjects=None):
         super().__init__(cityMCityObjects)
+
+    def get_textures(self):
+        """
+        Return a dictionary of all the textures where the keys are the IDs of the geometries.
+        :return: a dictionary of textures
+        """
+        texture_dict = dict()
+        uri_dict = dict()
+        for object_to_tile in self.get_objects():
+            uri = object_to_tile.texture_uri
+            if uri not in uri_dict:
+                stream = self.get_image_from_binary(uri, self.__class__, CityMCityObjects.gml_cursor)
+                uri_dict[uri] = Texture(stream)
+            texture_dict[object_to_tile.get_id()] = uri_dict[uri].get_cropped_texture_image(object_to_tile.geom.triangles[1])
+        return texture_dict
 
     @staticmethod
     def set_cursor(cursor):

--- a/py3dtilers/Common/object_to_tile.py
+++ b/py3dtilers/Common/object_to_tile.py
@@ -225,6 +225,16 @@ class ObjectsToTile(object):
             object_to_tile.set_triangles(new_geom)
             object_to_tile.set_box()
 
+    def get_textures(self):
+        """
+        Return a dictionary of all the textures where the keys are the IDs of the geometries.
+        :return: a dictionary of textures
+        """
+        texture_dict = dict()
+        for object_to_tile in self.get_objects():
+            texture_dict[object_to_tile.get_id()] = object_to_tile.get_texture()
+        return texture_dict
+
     @staticmethod
     def create_batch_table_extension(extension_name, ids=None, objects=None):
         pass

--- a/py3dtilers/ObjTiler/obj.py
+++ b/py3dtilers/ObjTiler/obj.py
@@ -68,8 +68,8 @@ class Obj(ObjectToTile):
             self.geom.triangles.append(uvs)
             if mesh.materials[0].texture is not None:
                 path = str(mesh.materials[0].texture._path).replace('\\', '/')
-                texture = Texture(path, self.geom.triangles[1])
-                self.set_texture(texture.get_texture_image())
+                texture = Texture(path)
+                self.set_texture(texture.get_cropped_texture_image(self.geom.triangles[1]))
         self.set_box()
 
         return True

--- a/py3dtilers/Texture/atlas.py
+++ b/py3dtilers/Texture/atlas.py
@@ -12,9 +12,10 @@ class Atlas():
         objects_with_id_key = dict()
         textures_with_id_key = dict()
 
+        textures = objects_to_tile.get_textures()
         for object_to_tile in objects_to_tile:
             objects_with_id_key[object_to_tile.get_id()] = object_to_tile.geom
-            textures_with_id_key[object_to_tile.get_id()] = object_to_tile.get_texture()
+            textures_with_id_key[object_to_tile.get_id()] = textures[object_to_tile.get_id()]
 
         # Sort textures by size, starting by the biggest one
         textures_sorted = sorted(textures_with_id_key.items(),

--- a/py3dtilers/Texture/texture.py
+++ b/py3dtilers/Texture/texture.py
@@ -6,18 +6,19 @@ class Texture():
 
     folder = None
 
-    def __init__(self, image_path, triangles):
+    def __init__(self, image_path):
         """
         :param image_path: path to the image (or a stream with image bytes)
-        :param triangles: the uvs
         Create a pillow.image:
         """
-        image = Image.open(image_path)
-        image = self.cropImage(image, triangles)
-        self.texture_image = image.convert("RGBA")
+        self.image = Image.open(image_path)
 
-    def get_texture_image(self):
-        return self.texture_image
+    def get_cropped_texture_image(self, uvs):
+        """
+        :param uvs: the uvs
+        """
+        image = self.cropImage(self.image, uvs)
+        return image.convert("RGBA")
 
     def cropImage(self, image, triangles):
         minX = 2


### PR DESCRIPTION
Create textured 3DTiles of relief, water bdies and bridges (see [issue](https://github.com/VCityTeam/py3dtilers/issues/43)). The main problem seemed to be in our 3DTiles viewer [UD-Viz](https://github.com/VCityTeam/UD-Viz) and was fixed in [this PR](https://github.com/VCityTeam/UD-Viz/pull/275).

This PR reduce the computation time of textured 3DTiles with the CityTiler.

- Choose the object type (buildings, relief, etc) with `--type` flag
- Add textures to water bodies
- Query texture images only once per tile. We used to query the same image a lot of time when many surfaces shared a texture

