### PR TITLE
Reduce memory usage of geometries in CityTiler

### DIFF
--- a/py3dtilers/Common/kd_tree.py
+++ b/py3dtilers/Common/kd_tree.py
@@ -1,7 +1,7 @@
 from .object_to_tile import ObjectsToTile
 
 
-def kd_tree(objects, maxNumObjects, depth=0):
+def kd_tree(objects_to_tile, maxNumObjects, depth=0):
     """
     Distribute the geometries into ObjectsToTile.
     The objects are distributed by their centroid.
@@ -13,10 +13,10 @@ def kd_tree(objects, maxNumObjects, depth=0):
     """
     # objects should herited from objects_to_tile and
     # dispose of a method get_centroid()
-    if (not isinstance(objects, ObjectsToTile)):
+    if (not isinstance(objects_to_tile, ObjectsToTile)):
         return None
 
-    derived = objects.__class__
+    derived = objects_to_tile.__class__
 
     # The module argument of 2 (in the next line) hard-wires the fact that
     # this kd_tree is in fact a 2D_tree.
@@ -26,12 +26,12 @@ def kd_tree(objects, maxNumObjects, depth=0):
     # bounding boxes of the city objects. And thus, depending on the value of
     # axis, we alternatively sort on the X or Y coordinate of those centroids:
 
-    sObjects = derived(
-        sorted(objects,
-               key=lambda obj: obj.get_centroid()[axis]))
-    median = len(sObjects) // 2
-    lObjects = sObjects[:median]
-    rObjects = sObjects[median:]
+    objects_to_tile.objects = sorted(objects_to_tile,
+               key=lambda obj: obj.get_centroid()[axis])
+    median = len(objects_to_tile) // 2
+    lObjects = objects_to_tile[:median]
+    rObjects = objects_to_tile[median:]
+    objects_to_tile = None
     pre_tiles = derived()
     if len(lObjects) > maxNumObjects:
         pre_tiles.extend(kd_tree(lObjects, maxNumObjects, depth + 1))

--- a/py3dtilers/Common/kd_tree.py
+++ b/py3dtilers/Common/kd_tree.py
@@ -27,11 +27,10 @@ def kd_tree(objects_to_tile, maxNumObjects, depth=0):
     # axis, we alternatively sort on the X or Y coordinate of those centroids:
 
     objects_to_tile.objects = sorted(objects_to_tile,
-               key=lambda obj: obj.get_centroid()[axis])
+                                     key=lambda obj: obj.get_centroid()[axis])
     median = len(objects_to_tile) // 2
     lObjects = objects_to_tile[:median]
     rObjects = objects_to_tile[median:]
-    objects_to_tile = None
     pre_tiles = derived()
     if len(lObjects) > maxNumObjects:
         pre_tiles.extend(kd_tree(lObjects, maxNumObjects, depth + 1))

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -30,6 +30,7 @@ class LodTree(GeometryTree):
 
             root_nodes.append(root_node)
 
+        objects_to_tile.objects = list()
         super().__init__(root_nodes)
 
     def group_features(self, objects_to_tile, polygons_path=None):

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -30,7 +30,6 @@ class LodTree(GeometryTree):
 
             root_nodes.append(root_node)
 
-        objects_to_tile.objects = list()
         super().__init__(root_nodes)
 
     def group_features(self, objects_to_tile, polygons_path=None):

--- a/py3dtilers/Common/object_to_tile.py
+++ b/py3dtilers/Common/object_to_tile.py
@@ -127,6 +127,10 @@ class ObjectsToTile(object):
                 objects.extend(objs.get_objects())
             return objects
 
+    def delete_objects_ref(self):
+        """Delete the reference to the objects contained by this instance, so the objects are destroyed when unused."""
+        self.objects = list()
+
     def __len__(self):
         return len(self.objects)
 

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -102,6 +102,7 @@ class Tiler():
         create_loa = self.args.loa is not None
 
         tree = self.create_tree(objects_to_tile, self.args.lod1, create_loa, self.args.loa, self.args.with_texture)
+        objects_to_tile.delete_objects_ref()
         return FromGeometryTreeToTileset.convert_to_tileset(tree, extension_name)
 
     def create_directory(self, directory):

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -57,6 +57,7 @@ class FromGeometryTreeToTileset():
         # Else, add the created tile to its parent's children
         else:
             parent.add_child(tile)
+        node.objects_to_tile.objects = list()
 
         for child_node in node.child_nodes:
             FromGeometryTreeToTileset.__create_tile(child_node, tile, centroid, [0., 0., 0.], depth + 1, extension_name)

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -57,7 +57,7 @@ class FromGeometryTreeToTileset():
         # Else, add the created tile to its parent's children
         else:
             parent.add_child(tile)
-        node.objects_to_tile.objects = list()
+        node.objects_to_tile.delete_objects_ref()
 
         for child_node in node.child_nodes:
             FromGeometryTreeToTileset.__create_tile(child_node, tile, centroid, [0., 0., 0.], depth + 1, extension_name)


### PR DESCRIPTION
Create less intances of `ObjectsToTile` (or child classes) and delete the reference to their objects once they are no longer used. This allows the garbage collector to destroy the `ObjectToTile` (triangles, UVs, etc) once they are writen as binary in a tile.

This PR lightly reduce the memory usage over time of the CityTiler.