### PR TITLE
[CityTiler] don't drop city objects that don't have an envelope in database

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -126,23 +126,27 @@ class CityTiler(Tiler):
 
         :return: a tileset.
         """
+        print('Retrieving city objects from database...')
         cityobjects = CityMCityObjects.retrieve_objects(cursor, objects_type)
 
         if not cityobjects:
             raise ValueError(f'The database does not contain any {objects_type} object')
 
         if self.args.with_texture:
+            print('Retrieving surface with textures from database...')
             self.get_surfaces_with_texture(cursor, cityobjects, objects_type)
         else:
             if split_surfaces:
+                print('Retrieving split surfaces from database...')
                 self.get_surfaces_split(cursor, cityobjects, objects_type)
             else:
+                print('Retrieving merged surfaces from database...')
                 self.get_surfaces_merged(cursor, cityobjects, objects_type)
 
         extension_name = None
         if CityMBuildings.is_bth_set():
             extension_name = "batch_table_hierarchy"
-
+        print('Creating tileset from geometries...')
         return self.create_tileset_from_geometries(cityobjects, extension_name=extension_name)
 
 
@@ -157,6 +161,7 @@ def main():
     city_tiler.parse_command_line()
     args = city_tiler.args
 
+    print('Connecting to database...')
     cursor = open_data_base(args.db_config_path[0])
 
     if args.type == "building":

--- a/py3dtilers/CityTiler/citym_bridge.py
+++ b/py3dtilers/CityTiler/citym_bridge.py
@@ -35,13 +35,13 @@ class CityMBridges(CityMCityObjects):
         if not bridges:
             # No specific bridges were sought. We thus retrieve all the ones
             # we can find in the database:
-            query = "SELECT bridge.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT bridge.id, cityobject.gmlid " + \
                     "FROM citydb.bridge JOIN citydb.cityobject ON bridge.id=cityobject.id " + \
                     "WHERE bridge.id=bridge.bridge_root_id"
         else:
             bridge_gmlids = [n.get_gml_id() for n in bridges]
             bridge_gmlids_as_string = "('" + "', '".join(bridge_gmlids) + "')"
-            query = "SELECT bridge.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT bridge.id, cityobject.gmlid " + \
                     "FROM citydb.bridge JOIN citydb.cityobject ON bridge.id=cityobject.id " + \
                     "WHERE cityobject.gmlid IN " + bridge_gmlids_as_string + " " + \
                     "AND bridge.id=bridge.bridge_root_id"

--- a/py3dtilers/CityTiler/citym_building.py
+++ b/py3dtilers/CityTiler/citym_building.py
@@ -64,13 +64,13 @@ class CityMBuildings(CityMCityObjects):
         if not buildings:
             # No specific buildings were sought. We thus retrieve all the ones
             # we can find in the database:
-            query = "SELECT building.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT building.id, cityobject.gmlid " + \
                     "FROM citydb.building JOIN citydb.cityobject ON building.id=cityobject.id " + \
                     "WHERE building.id=building.building_root_id"
         else:
             building_gmlids = [n.get_gml_id() for n in buildings]
             building_gmlids_as_string = "('" + "', '".join(building_gmlids) + "')"
-            query = "SELECT building.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT building.id, cityobject.gmlid " + \
                     "FROM citydb.building JOIN citydb.cityobject ON building.id=cityobject.id " + \
                     "WHERE cityobject.gmlid IN " + building_gmlids_as_string + " " + \
                     "AND building.id=building.building_root_id"

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -120,17 +120,9 @@ class CityMCityObjects(ObjectsToTile):
             for cityobject in cityobjects:
                 objects_with_gmlid_key[cityobject.get_gml_id()] = cityobject
 
-        for t in cursor.fetchall():
-            object_id = t[0]
-            if not t[1]:
-                print("Warning: object with id ", object_id)
-                print("         has no 'cityobject.envelope'.")
-                if no_input:
-                    print("     Dropping this object (downstream trouble ?)")
-                    continue
-                print("     Exiting (is the database corrupted ?)")
-                sys.exit(1)
-            gml_id = t[2]
+        for obj in cursor.fetchall():
+            object_id = obj[0]
+            gml_id = obj[2]
             if no_input:
                 new_object = object_type(object_id, gml_id)
                 result_objects.append(new_object)

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -122,7 +122,7 @@ class CityMCityObjects(ObjectsToTile):
 
         for obj in cursor.fetchall():
             object_id = obj[0]
-            gml_id = obj[2]
+            gml_id = obj[1]
             if no_input:
                 new_object = object_type(object_id, gml_id)
                 result_objects.append(new_object)

--- a/py3dtilers/CityTiler/citym_relief.py
+++ b/py3dtilers/CityTiler/citym_relief.py
@@ -50,13 +50,13 @@ class CityMReliefs(CityMCityObjects):
         if not reliefs:
             # No specific reliefs were sought. We thus retrieve all the ones
             # we can find in the database:
-            query = "SELECT relief_feature.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT relief_feature.id, cityobject.gmlid " + \
                     "FROM citydb.relief_feature JOIN citydb.cityobject ON relief_feature.id=cityobject.id"
 
         else:
             relief_gmlids = [n.get_gml_id() for n in reliefs]
             relief_gmlids_as_string = "('" + "', '".join(relief_gmlids) + "')"
-            query = "SELECT relief_feature.id, BOX3D(cityobject.envelope) " + \
+            query = "SELECT relief_feature.id, cityobject.gmlid " + \
                     "FROM citydb.relief_feature JOIN citydb.cityobject ON relief_feature.id=cityobject.id" + \
                     "WHERE cityobject.gmlid IN " + relief_gmlids_as_string
 

--- a/py3dtilers/CityTiler/citym_waterbody.py
+++ b/py3dtilers/CityTiler/citym_waterbody.py
@@ -50,13 +50,13 @@ class CityMWaterBodies(CityMCityObjects):
         if not waterbodies:
             # No specific waterbodies were sought. We thus retrieve all the ones
             # we can find in the database:
-            query = "SELECT waterbody.id, BOX3D(cityobject.envelope), cityobject.gmlid " + \
+            query = "SELECT waterbody.id, cityobject.gmlid " + \
                     "FROM citydb.waterbody JOIN citydb.cityobject ON waterbody.id=cityobject.id"
 
         else:
             waterbody_gmlids = [n.get_gml_id() for n in waterbodies]
             waterbody_gmlids_as_string = "('" + "', '".join(waterbody_gmlids) + "')"
-            query = "SELECT waterbody.id, BOX3D(cityobject.envelope) " + \
+            query = "SELECT waterbody.id, cityobject.gmlid " + \
                     "FROM citydb.waterbody JOIN citydb.cityobject ON waterbody.id=cityobject.id" + \
                     "WHERE cityobject.gmlid IN " + waterbody_gmlids_as_string
 


### PR DESCRIPTION
Remove the cityobject envelope from 3D City DB city objects query since it is not used at this stage. The envelope is computed later on, from the geometries, in the `get_surfaces_...` methods of the CityTiler, e.g. [here](https://github.com/VCityTeam/py3dtilers/blob/master/py3dtilers/CityTiler/CityTiler.py#L56).

Subsequently, don't drop city objects that don't have an envelope in the database.