### PR TITLE
Create and write tileset tile by tile

### DIFF
--- a/py3dtilers/CityTiler/CityTemporalTiler.py
+++ b/py3dtilers/CityTiler/CityTemporalTiler.py
@@ -337,7 +337,7 @@ def main():
 
     [cursor.close() for cursor in cursors]  # We are done with the databases
 
-    tile_set.write_to_directory(city_temp_tiler.get_output_dir())
+    tile_set.write_as_json(city_temp_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -113,10 +113,11 @@ class CityTiler(Tiler):
             raise ValueError(f'The database does not contain any {objects_type} object')
         self.set_features_centroid(cursor, cityobjects, objects_type)
 
+        kd_tree_max = 25 if self.args.with_texture else 500
         extension_name = None
         if CityMBuildings.is_bth_set():
             extension_name = "batch_table_hierarchy"
-        return self.create_tileset_from_geometries(cityobjects, extension_name=extension_name)
+        return self.create_tileset_from_geometries(cityobjects, extension_name=extension_name, kd_tree_max=kd_tree_max)
 
 
 def main():

--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -100,17 +100,6 @@ class CityTiler(Tiler):
         if not cityobjects:
             raise ValueError(f'The database does not contain any {objects_type.__name__} object')
 
-        if self.args.with_texture:
-            print('Retrieving surface with textures from database...')
-            self.get_surfaces_with_texture(cursor, cityobjects, objects_type)
-        else:
-            if split_surfaces:
-                print('Retrieving split surfaces from database...')
-                self.get_surfaces_split(cursor, cityobjects, objects_type)
-            else:
-                print('Retrieving merged surfaces from database...')
-                self.get_surfaces_merged(cursor, cityobjects, objects_type)
-            raise ValueError(f'The database does not contain any {objects_type} object')
         self.set_features_centroid(cursor, cityobjects, objects_type)
 
         kd_tree_max = 25 if self.args.with_texture else 500

--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -159,7 +159,7 @@ def main():
     tileset.add_asset_extras(origin)
 
     cursor.close()
-    tileset.write_to_directory(city_tiler.get_output_dir())
+    tileset.write_as_json(city_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -72,7 +72,7 @@ class CityMCityObject(Feature):
                 feature_id = t[0]
                 geom_as_string = t[1]
                 if geom_as_string is not None:
-                    cityobject = self.__class__(feature_id)
+                    cityobject = self.__class__(feature_id, self.get_gml_id())
                     associated_data = []
 
                     if user_arguments.with_texture:

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -82,8 +82,10 @@ class CityMCityObject(Feature):
                         associated_data = [uv_as_string]
 
                     cityobject.geom = TriangleSoup.from_wkb_multipolygon(geom_as_string, associated_data)
-                    cityobject.set_box()
-                    cityobjects_with_geom.append(cityobject)
+                    if len(cityobject.geom.triangles[0]) > 0:
+                        cityobject.set_box()
+                        cityobject.centroid = self.centroid
+                        cityobjects_with_geom.append(cityobject)
             except Exception:
                 continue
         return cityobjects_with_geom

--- a/py3dtilers/CityTiler/temporal_building.py
+++ b/py3dtilers/CityTiler/temporal_building.py
@@ -39,3 +39,13 @@ class TemporalBuilding(CityMBuilding):
     def get_time_stamp(self):
         # This should be of type date and by default is manipulated as string:
         return self.temporal_id.split('::')[0]
+
+    def get_geom(self, user_arguments=None):
+        """
+        Get the geometry of the feature.
+        :return: a boolean
+        """
+        if self.geom is not None and len(self.geom.triangles) > 0 and len(self.get_geom_as_triangles()) > 0:
+            return [self]
+        else:
+            return []

--- a/py3dtilers/Common/__init__.py
+++ b/py3dtilers/Common/__init__.py
@@ -3,6 +3,7 @@ from .feature import Feature, FeatureList
 from .tree_with_children_and_parent import TreeWithChildrenAndParent
 from .group import Groups
 from .polygon_extrusion import ExtrudedPolygon
+from .lod_feature_list import LoaFeatureList, Lod1FeatureList
 from .geometry_node import GeometryNode
 from .geometry_tree import GeometryTree
 from .lod_node import Lod1Node, LoaNode
@@ -17,6 +18,8 @@ __all__ = ['kd_tree',
            'TreeWithChildrenAndParent',
            'Groups',
            'ExtrudedPolygon',
+           'Lod1FeatureList',
+           'LoaFeatureList',
            'GeometryNode',
            'GeometryTree',
            'Lod1Node',

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -120,6 +120,16 @@ class Feature(object):
         """
         return self.texture is not None
 
+    def get_geom(self, user_arguments=None):
+        """
+        Get the geometry of the feature.
+        :return: a boolean
+        """
+        if self.geom is not None and len(self.geom.triangles) > 0 and len(self.get_geom_as_triangles()) > 0:
+            return [self]
+        else:
+            return []
+
 
 class FeatureList(object):
     """
@@ -274,6 +284,16 @@ class FeatureList(object):
         for feature in self.get_features():
             texture_dict[feature.get_id()] = feature.get_texture()
         return texture_dict
+
+    def set_features_geom(self, user_arguments=None):
+        """
+        Set the geometry of the features.
+        Keep only the features with geometry.
+        """
+        features_with_geom = list()
+        for feature in self.objects:
+            features_with_geom.extend(feature.get_geom(user_arguments))
+        self.objects = features_with_geom
 
     @staticmethod
     def create_batch_table_extension(extension_name, ids=None, objects=None):

--- a/py3dtilers/Common/geometry_node.py
+++ b/py3dtilers/Common/geometry_node.py
@@ -13,7 +13,7 @@ class GeometryNode():
         """
         self.feature_list = feature_list
         self.child_nodes = list()
-        self.with_texture = with_texture and self.geometries_have_texture()
+        self.with_texture = with_texture
         self.geometric_error = geometric_error
 
     def set_child_nodes(self, nodes=list()):
@@ -35,7 +35,7 @@ class GeometryNode():
         Return True if this node must keep the texture of its features.
         :return: boolean
         """
-        return self.with_texture
+        return self.with_texture and self.geometries_have_texture()
 
     def geometries_have_texture(self):
         """
@@ -47,12 +47,19 @@ class GeometryNode():
     def get_features(self):
         """
         Return the features in this node and the features in the child nodes (recursively).
-        :return: a FeatureList
+        :return: a list of Feature
         """
         objects = [self.feature_list]
         for child in self.child_nodes:
             objects.extend(child.get_features())
         return objects
+
+    def set_node_features_geometry(self, user_arguments=None):
+        """
+        Set the geometry of the features in this node and the features in the child nodes (recursively).
+        """
+        for features in reversed(self.get_features()):
+            features.set_features_geom(user_arguments)
 
     def get_leaves(self):
         """

--- a/py3dtilers/Common/group.py
+++ b/py3dtilers/Common/group.py
@@ -58,13 +58,14 @@ class Groups():
     Contains a list of Group
     """
 
-    def __init__(self, feature_list, polygons_path=None):
+    def __init__(self, feature_list, polygons_path=None, kd_tree_max=500):
         """
         Distribute the features contained in feature_list into different Group
         The way to distribute the features depends on the parameters
         :param feature_list: an instance of FeatureList containing features to distribute into Group
         :param polygons_path: the path to a folder containing polygons as .geojson files.
         When this param is not None, it means we want to group features by polygons
+        :param kd_tree_max: the maximum number of features in each list created by the kd_tree
         """
         self.materials = feature_list.materials
         if feature_list.is_list_of_feature_list():
@@ -72,7 +73,7 @@ class Groups():
         elif polygons_path is not None:
             self.group_objects_by_polygons(feature_list, polygons_path)
         else:
-            self.group_objects_with_kdtree(feature_list)
+            self.group_objects_with_kdtree(feature_list, kd_tree_max)
         self.set_materials(self.materials)
 
     def get_groups_as_list(self):
@@ -100,13 +101,15 @@ class Groups():
             groups.append(group)
         self.groups = groups
 
-    def group_objects_with_kdtree(self, feature_list):
+    def group_objects_with_kdtree(self, feature_list, kd_tree_max=500):
         """
-        Create groups of features. The features are distributed into groups of (max) 500 objects.
+        Create groups of features. The features are distributed into FeatureList of (by default) max 500 features.
         The distribution depends on the centroid of each feature.
+        :param feature_list: a FeatureList
+        :param kd_tree_max: the maximum number of features in each FeatureList
         """
         groups = list()
-        objects = kd_tree(feature_list, 500)
+        objects = kd_tree(feature_list, kd_tree_max)
         for feature_list in objects:
             group = Group(feature_list)
             groups.append(group)

--- a/py3dtilers/Common/group.py
+++ b/py3dtilers/Common/group.py
@@ -58,6 +58,9 @@ class Groups():
     Contains a list of Group
     """
 
+    # Used to put in a same group the features which are in a same 1000 m^3 cube.
+    DEFAULT_CUBE_SIZE = 1000
+
     def __init__(self, feature_list, polygons_path=None, kd_tree_max=500):
         """
         Distribute the features contained in feature_list into different Group
@@ -185,9 +188,9 @@ class Groups():
             group = Group(FeatureList([feature_list[feature_index]]))
             groups.append(group)
 
-        return self.distribute_groups_in_cubes(groups, 1000)
+        return self.distribute_groups_in_cubes(groups, Groups.DEFAULT_CUBE_SIZE)
 
-    def distribute_groups_in_cubes(self, groups, cube_size=300):
+    def distribute_groups_in_cubes(self, groups, cube_size):
         """
         Merges together the groups in order to reduce the number of tiles.
         The groups are distributed into cubes of a grid. The groups in the same cube are merged together.

--- a/py3dtilers/Common/lod_feature_list.py
+++ b/py3dtilers/Common/lod_feature_list.py
@@ -1,0 +1,67 @@
+import numpy as np
+from ..Common import FeatureList, ExtrudedPolygon
+
+
+class LodFeatureList(FeatureList):
+
+    def __init__(self, objects=None, features_node=None):
+        super().__init__(objects)
+        self.features_node = features_node
+        self.centroid = features_node.feature_list.get_centroid()
+
+    def get_centroid(self):
+        return self.centroid
+
+
+class Lod1FeatureList(LodFeatureList):
+
+    def set_features_geom(self, user_arguments=None):
+        """
+        Set the geometry of the features.
+        Keep only the features with geometry.
+        """
+        for i, feature in enumerate(self.features_node.feature_list):
+            extruded_polygon = ExtrudedPolygon("lod1_" + str(i), [feature])
+            extruded_polygon.set_geom()
+            self.objects.append(extruded_polygon)
+        self.features_node = None
+
+
+class LoaFeatureList(LodFeatureList):
+
+    loa_index = 0
+
+    def __init__(self, objects=None, points_dict=None, additional_points=None, features_node=None):
+        super().__init__(objects, features_node=features_node)
+        self.points_dict = points_dict
+        self.additional_points = additional_points
+
+    def set_features_geom(self, user_arguments=None):
+        """
+        Set the geometry of the features.
+        Keep only the features with geometry.
+        """
+        for key in self.points_dict:
+            contained_objects = FeatureList([self.features_node.feature_list[i] for i in self.points_dict[key]])
+            loa = self.create_loa_from_polygon(contained_objects, self.additional_points[key], LoaFeatureList.loa_index)
+            loa.set_geom()
+            LoaFeatureList.loa_index += 1
+            self.objects.append(loa)
+        self.features_node = None
+
+    def create_loa_from_polygon(self, feature_list, polygon_points, index=0):
+        """
+        Create a LOA (3D extrusion of a polygon). The LOA is a 3D geometry containing a group of features.
+        :param feature_list: the features contained in the LOA
+        :param polygon_points: a polygon as list of 3D points
+        :param int index: an index used for the LOA identifier
+
+        :return: a 3D extrusion of the polygon
+        """
+        centroid = np.array([0, 0, 0], dtype=np.float64)
+        for feature in feature_list:
+            centroid += feature.get_centroid()
+        centroid /= len(feature_list)
+
+        extruded_polygon = ExtrudedPolygon("loa_" + str(index), feature_list, polygon=polygon_points)
+        return extruded_polygon

--- a/py3dtilers/Common/lod_feature_list.py
+++ b/py3dtilers/Common/lod_feature_list.py
@@ -1,4 +1,5 @@
 import numpy as np
+from shapely.geometry import Point, Polygon
 from ..Common import FeatureList, ExtrudedPolygon
 
 
@@ -31,37 +32,58 @@ class LoaFeatureList(LodFeatureList):
 
     loa_index = 0
 
-    def __init__(self, objects=None, points_dict=None, additional_points=None, features_node=None):
+    def __init__(self, objects=None, polygons=list(), features_node=None):
         super().__init__(objects, features_node=features_node)
-        self.points_dict = points_dict
-        self.additional_points = additional_points
+        self.polygons = polygons
 
     def set_features_geom(self, user_arguments=None):
         """
         Set the geometry of the features.
         Keep only the features with geometry.
         """
-        for key in self.points_dict:
-            contained_objects = FeatureList([self.features_node.feature_list[i] for i in self.points_dict[key]])
-            loa = self.create_loa_from_polygon(contained_objects, self.additional_points[key], LoaFeatureList.loa_index)
-            loa.set_geom()
-            LoaFeatureList.loa_index += 1
-            self.objects.append(loa)
+        features = self.features_node.feature_list.objects.copy()
+
+        for polygon in self.polygons:
+            feature_list = FeatureList(self.find_features_in_polygon(features, Polygon(polygon)))
+            if len(feature_list) > 0:
+                [features.remove(feature) for feature in feature_list]
+                self.objects.append(self.create_loa(feature_list, polygon))
+
+        for feature in features:
+            self.objects.append(self.create_loa(FeatureList([feature])))
+
         self.features_node = None
 
-    def create_loa_from_polygon(self, feature_list, polygon_points, index=0):
+    def find_features_in_polygon(self, features, polygon):
+        """
+        Find all the features which are in the polygon.
+        :param features: a list of Feature
+        :param polygon: a Shapely Polygon
+        :return: a list of Feature
+        """
+        features_in_polygon = list()
+        for feature in features:
+            p = Point(feature.get_centroid())
+            if p.within(polygon):
+                features_in_polygon.append(feature)
+        return features_in_polygon
+
+    def create_loa(self, feature_list, polygon=None):
         """
         Create a LOA (3D extrusion of a polygon). The LOA is a 3D geometry containing a group of features.
         :param feature_list: the features contained in the LOA
-        :param polygon_points: a polygon as list of 3D points
+        :param polygon: a polygon as list of 3D points
         :param int index: an index used for the LOA identifier
 
         :return: a 3D extrusion of the polygon
         """
+        index = LoaFeatureList.loa_index
+        LoaFeatureList.loa_index += 1
+
         centroid = np.array([0, 0, 0], dtype=np.float64)
         for feature in feature_list:
             centroid += feature.get_centroid()
         centroid /= len(feature_list)
 
-        extruded_polygon = ExtrudedPolygon("loa_" + str(index), feature_list, polygon=polygon_points)
+        extruded_polygon = ExtrudedPolygon("loa_" + str(index), feature_list, polygon=polygon)
         return extruded_polygon

--- a/py3dtilers/Common/lod_feature_list.py
+++ b/py3dtilers/Common/lod_feature_list.py
@@ -1,4 +1,3 @@
-import numpy as np
 from shapely.geometry import Point, Polygon
 from ..Common import FeatureList, ExtrudedPolygon
 
@@ -9,9 +8,6 @@ class LodFeatureList(FeatureList):
         super().__init__(objects)
         self.features_node = features_node
         self.centroid = features_node.feature_list.get_centroid()
-
-    def get_centroid(self):
-        return self.centroid
 
 
 class Lod1FeatureList(LodFeatureList):
@@ -79,11 +75,6 @@ class LoaFeatureList(LodFeatureList):
         """
         index = LoaFeatureList.loa_index
         LoaFeatureList.loa_index += 1
-
-        centroid = np.array([0, 0, 0], dtype=np.float64)
-        for feature in feature_list:
-            centroid += feature.get_centroid()
-        centroid /= len(feature_list)
 
         extruded_polygon = ExtrudedPolygon("loa_" + str(index), feature_list, polygon=polygon)
         return extruded_polygon

--- a/py3dtilers/Common/lod_node.py
+++ b/py3dtilers/Common/lod_node.py
@@ -1,5 +1,5 @@
-from ..Common import FeatureList, Feature, GeometryNode
-from ..Common import ExtrudedPolygon
+from ..Common import GeometryNode
+from ..Common import Lod1FeatureList, LoaFeatureList
 
 
 class Lod1Node(GeometryNode):
@@ -7,12 +7,9 @@ class Lod1Node(GeometryNode):
     Creates 3D extrusions of the footprint of each feature in the feature_list parameter of the constructor.
     """
 
-    def __init__(self, feature_list, geometric_error=50):
-        lod1_list = list()
-        for feature in feature_list:
-            extruded_polygon = ExtrudedPolygon(feature)
-            lod1_list.append(extruded_polygon.get_extruded_object())
-        super().__init__(feature_list=FeatureList(lod1_list), geometric_error=geometric_error)
+    def __init__(self, features_node, geometric_error=50):
+        feature_list = Lod1FeatureList(features_node=features_node)
+        super().__init__(feature_list, geometric_error=geometric_error)
 
 
 class LoaNode(GeometryNode):
@@ -20,29 +17,7 @@ class LoaNode(GeometryNode):
     Creates 3D extrusions of the polygons given as parameter.
     The LoaNode also takes a dictionary stocking the indexes of the features contained in each polygon.
     """
-    loa_index = 0
 
-    def __init__(self, feature_list, geometric_error=50, additional_points=list(), points_dict=dict()):
-        loas = list()
-        for key in points_dict:
-            contained_objects = FeatureList([feature_list[i] for i in points_dict[key]])
-            loa = self.create_loa_from_polygon(contained_objects, additional_points[key], LoaNode.loa_index)
-            loas.append(loa)
-            LoaNode.loa_index += 1
-        super().__init__(feature_list=FeatureList(loas), geometric_error=geometric_error)
-
-    def create_loa_from_polygon(self, feature_list, polygon_points, index=0):
-        """
-        Create a LOA (3D extrusion of a polygon). The LOA is a 3D geometry containing a group of features.
-        :param feature_list: the features contained in the LOA
-        :param polygon_points: a polygon as list of 3D points
-        :param int index: an index used for the LOA identifier
-
-        :return: a 3D extrusion of the polygon
-        """
-        loa_geometry = Feature("loa_" + str(index))
-        for feature in feature_list:
-            loa_geometry.geom.triangles.append(feature.geom.triangles[0])
-
-        extruded_polygon = ExtrudedPolygon(loa_geometry, override_points=True, polygon=polygon_points)
-        return extruded_polygon.get_extruded_object()
+    def __init__(self, features_node, geometric_error=50, additional_points=list(), points_dict=dict()):
+        feature_list = LoaFeatureList(points_dict=points_dict, additional_points=additional_points, features_node=features_node)
+        super().__init__(feature_list, geometric_error=geometric_error)

--- a/py3dtilers/Common/lod_node.py
+++ b/py3dtilers/Common/lod_node.py
@@ -18,6 +18,6 @@ class LoaNode(GeometryNode):
     The LoaNode also takes a dictionary stocking the indexes of the features contained in each polygon.
     """
 
-    def __init__(self, features_node, geometric_error=50, additional_points=list(), points_dict=dict()):
-        feature_list = LoaFeatureList(points_dict=points_dict, additional_points=additional_points, features_node=features_node)
+    def __init__(self, features_node, geometric_error=50, polygons=list()):
+        feature_list = LoaFeatureList(polygons=polygons, features_node=features_node)
         super().__init__(feature_list, geometric_error=geometric_error)

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -20,11 +20,11 @@ class LodTree(GeometryTree):
             node = GeometryNode(group.feature_list, 1, with_texture)
             root_node = node
             if create_lod1:
-                lod1_node = Lod1Node(group.feature_list, 5)
+                lod1_node = Lod1Node(node, 5)
                 lod1_node.add_child_node(root_node)
                 root_node = lod1_node
             if group.with_polygon:
-                loa_node = LoaNode(group.feature_list, 20, group.additional_points, group.points_dict)
+                loa_node = LoaNode(node, 20, group.additional_points, group.points_dict)
                 loa_node.add_child_node(root_node)
                 root_node = loa_node
 

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -23,8 +23,8 @@ class LodTree(GeometryTree):
                 lod1_node = Lod1Node(node, 5)
                 lod1_node.add_child_node(root_node)
                 root_node = lod1_node
-            if group.with_polygon:
-                loa_node = LoaNode(node, 20, group.additional_points, group.points_dict)
+            if create_loa:
+                loa_node = LoaNode(node, 20, group.polygons)
                 loa_node.add_child_node(root_node)
                 root_node = loa_node
 

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -6,7 +6,7 @@ class LodTree(GeometryTree):
     The LodTree contains the root node(s) of the LOD hierarchy and the centroid of the whole tileset
     """
 
-    def __init__(self, feature_list, create_lod1=False, create_loa=False, polygons_path=None, with_texture=False):
+    def __init__(self, feature_list, create_lod1=False, create_loa=False, polygons_path=None, with_texture=False, kd_tree_max=500):
         """
         LodTree takes an instance of FeatureList (which contains a collection of Feature) and creates nodes.
         In order to reduce the number of .b3dm, it also distributes the features into a list of Group.
@@ -14,7 +14,7 @@ class LodTree(GeometryTree):
         """
         root_nodes = list()
 
-        groups = self.group_features(feature_list, polygons_path)
+        groups = self.group_features(feature_list, polygons_path, kd_tree_max)
 
         for group in groups:
             node = GeometryNode(group.feature_list, 1, with_texture)
@@ -32,13 +32,13 @@ class LodTree(GeometryTree):
 
         super().__init__(root_nodes)
 
-    def group_features(self, feature_list, polygons_path=None):
+    def group_features(self, feature_list, polygons_path=None, kd_tree_max=500):
         """
         Distribute feature_list into groups to reduce the number of tiles.
         :param feature_list: a FeatureList to distribute into groups.
         :param polygons_path: a path to the file(s) containing polygons (used for LOA creation)
-
+        :param kd_tree_max: the maximum number of features in each list created by the kd_tree
         :return: a list of groups, each group containing features
         """
-        groups = Groups(feature_list, polygons_path)
+        groups = Groups(feature_list, polygons_path, kd_tree_max)
         return groups.get_groups_as_list()

--- a/py3dtilers/Common/polygon_extrusion.py
+++ b/py3dtilers/Common/polygon_extrusion.py
@@ -2,6 +2,7 @@ import numpy as np
 from ..Common import Feature
 from alphashape import alphashape
 from earclip import triangulate
+from shapely.geometry import Polygon
 
 
 class ExtrudedPolygon(Feature):
@@ -47,7 +48,11 @@ class ExtrudedPolygon(Feature):
             points = self.polygon
         else:
             hull = alphashape(points, 0.)
-            points = hull.exterior.coords[:-1]
+            try:
+                points = hull.exterior.coords[:-1]
+            except AttributeError:
+                po = hull.parallel_offset(0.1, 'right')
+                points = Polygon([*list(hull.coords), *list(po.coords)[::-1]]).exterior.coords[:-1]
 
         self.points = points
         self.min_height = minZ

--- a/py3dtilers/Common/polygon_extrusion.py
+++ b/py3dtilers/Common/polygon_extrusion.py
@@ -16,6 +16,7 @@ class ExtrudedPolygon(Feature):
         super().__init__(id)
         self.polygon = polygon
         self.features = features
+        self.set_geom()
 
     def set_geom(self):
         """

--- a/py3dtilers/Common/polygon_extrusion.py
+++ b/py3dtilers/Common/polygon_extrusion.py
@@ -4,8 +4,8 @@ from alphashape import alphashape
 from earclip import triangulate
 
 
-class ExtrudedPolygon():
-    def __init__(self, feature, override_points=False, polygon=None):
+class ExtrudedPolygon(Feature):
+    def __init__(self, id, features, polygon=None):
         """
         Creates a 3D extrusion of the footprint of a Feature
         :param feature: an instance of Feature containing triangles
@@ -13,39 +13,46 @@ class ExtrudedPolygon():
         but another polygon
         :param polygon: the polygon that will be extruded instead of the footprint (when overriding points)
         """
-        geom_triangles = feature.geom.triangles
+        super().__init__(id)
+        self.polygon = polygon
+        self.features = features
+
+    def set_geom(self):
+        """
+        Set the geometry of the feature.
+        :return: a boolean
+        """
+        geom_triangles = list()
+        for feature in self.features:
+            geom_triangles.extend(feature.get_geom_as_triangles())
+
         points = list()
         minZ = np.Inf
         average_maxZ = 0
 
         # Compute the footprint of the geometry
-        for triangles in geom_triangles:
+        for triangle in geom_triangles:
             maxZ = np.NINF
-            for triangle in triangles:
-                for point in triangle:
-                    if len(point) >= 3:
-                        points.append([point[0], point[1]])
-                        if point[2] < minZ:
-                            minZ = point[2]
-                        if point[2] > maxZ:
-                            maxZ = point[2]
+            for point in triangle:
+                if len(point) >= 3:
+                    points.append([point[0], point[1]])
+                    if point[2] < minZ:
+                        minZ = point[2]
+                    if point[2] > maxZ:
+                        maxZ = point[2]
             average_maxZ += maxZ
         average_maxZ /= len(geom_triangles)
-        if override_points:
-            points = polygon
+        if self.polygon is not None:
+            points = self.polygon
         else:
             hull = alphashape(points, 0.)
             points = hull.exterior.coords[:-1]
 
-        self.feature = feature
         self.points = points
         self.min_height = minZ
         self.max_height = average_maxZ
 
         self.extrude_footprint()
-
-    def get_extruded_object(self):
-        return self.extruded_object
 
     def extrude_footprint(self):
         coordinates = self.points
@@ -74,7 +81,6 @@ class ExtrudedPolygon():
             triangles.append([vertices[i], vertices[length + i], vertices[length + ((i + 1) % length)]])
             triangles.append([vertices[i], vertices[length + ((i + 1) % length)], vertices[((i + 1) % length)]])
 
-        extruded_object = Feature(str(self.feature.get_id()) + "_extrude")
-        extruded_object.geom.triangles.append(triangles)
-        extruded_object.set_box()
-        self.extruded_object = extruded_object
+        self.feature_list = None
+        self.geom.triangles.append(triangles)
+        self.set_box()

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -87,23 +87,24 @@ class Tiler():
         else:
             return self.args.output_dir
 
-    def create_tree(self, feature_list, create_lod1=False, create_loa=False, polygons_path=None, with_texture=False):
-        lod_tree = LodTree(feature_list, create_lod1, create_loa, polygons_path, with_texture)
+    def create_tree(self, feature_list, create_lod1=False, create_loa=False, polygons_path=None, with_texture=False, kd_tree_max=500):
+        lod_tree = LodTree(feature_list, create_lod1, create_loa, polygons_path, with_texture, kd_tree_max)
         return lod_tree
 
-    def create_tileset_from_geometries(self, feature_list, extension_name=None):
+    def create_tileset_from_geometries(self, feature_list, extension_name=None, kd_tree_max=500):
         """
         Create the 3DTiles tileset from the features.
         :param feature_list: a FeatureList
         :param extension_name: an optional extension to add to the tileset
+        :param kd_tree_max: the maximum number of features in each list created by the kd_tree
         :return: a TileSet
         """
         create_loa = self.args.loa is not None
-        tree = self.create_tree(feature_list, self.args.lod1, create_loa, self.args.loa, self.args.with_texture)
+        tree = self.create_tree(feature_list, self.args.lod1, create_loa, self.args.loa, self.args.with_texture, kd_tree_max)
 
         feature_list.delete_objects_ref()
         self.create_output_directory()
-        return FromGeometryTreeToTileset.convert_to_tileset(tree, self.args, extension_name)
+        return FromGeometryTreeToTileset.convert_to_tileset(tree, self.args, extension_name, self.get_output_dir())
 
     def create_output_directory(self):
         """

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -28,10 +28,12 @@ class FromGeometryTreeToTileset():
         FromGeometryTreeToTileset.nb_nodes = geometry_tree.get_number_of_nodes()
         centroid = geometry_tree.get_centroid()
         obj_writer = ObjWriter()
-        for root_node in geometry_tree.root_nodes:
+        while len(geometry_tree.root_nodes) > 0:
+            root_node = geometry_tree.root_nodes[0]
             root_node.set_node_features_geometry(user_arguments)
             FromGeometryTreeToTileset.__transform_node(root_node, centroid, user_arguments, obj_writer=obj_writer)
             FromGeometryTreeToTileset.__create_tile(root_node, tileset, centroid, centroid, 0, extension_name)
+            geometry_tree.root_nodes.remove(root_node)
 
         if user_arguments.obj is not None:
             obj_writer.write_obj(user_arguments.obj)

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -20,9 +20,11 @@ class FromGeometryTreeToTileset():
         """
         Recursively creates a tileset from the nodes of a GeometryTree
         :param geometry_tree: an instance of GeometryTree to transform into 3DTiles.
+        :param user_arguments: the Namespace containing the arguments of the command line.
         :param extension_name: the name of an extension to add to the tileset.
+        :param output_dir: the directory where the TileSet is writen.
 
-        :return: a Tileset
+        :return: a TileSet
         """
         print('Creating tileset from features...')
         tileset = TileSet()
@@ -44,6 +46,15 @@ class FromGeometryTreeToTileset():
 
     @staticmethod
     def __transform_node(node, tree_centroid, user_args, obj_writer=None):
+        """
+        Apply transformations on the features contained in a node.
+        Those transformations are based on the arguments of the user.
+        The features can also be writen in an OBJ file.
+        :param node: the GeometryNode to transform.
+        :param tree_centroid: the centroid of the GeometryTree.
+        :param user_args: the Namespace containing the arguments of the command line.
+        :param obj_writer: the writer used to create the OBJ model.
+        """
         if hasattr(user_args, 'scale') and user_args.scale:
             for objects in node.get_features():
                 objects.scale_features(user_args.scale)

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -220,7 +220,7 @@ def main():
         tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color)
         if(tileset is not None):
             print("tileset in", geojson_tiler.get_output_dir())
-            tileset.write_to_directory(geojson_tiler.get_output_dir())
+            tileset.write_as_json(geojson_tiler.get_output_dir())
     else:
         print(path, "is neither a geojson file or a directory. Please target geojson file or a directory containing geojson files.")
 

--- a/py3dtilers/IfcTiler/IfcTiler.py
+++ b/py3dtilers/IfcTiler/IfcTiler.py
@@ -66,7 +66,7 @@ def main():
     tileset = ifc_tiler.from_ifc(args.file_path, args.grouped_by, args.originalUnit, args.targetedUnit)
 
     if(tileset is not None):
-        tileset.write_to_directory(ifc_tiler.get_output_dir())
+        tileset.write_as_json(ifc_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/ObjTiler/ObjTiler.py
+++ b/py3dtilers/ObjTiler/ObjTiler.py
@@ -75,7 +75,7 @@ def main():
             tileset = obj_tiler.from_obj_directory(path)
             if(tileset is not None):
                 print("tileset in", obj_tiler.get_output_dir())
-                tileset.write_to_directory(obj_tiler.get_output_dir())
+                tileset.write_as_json(obj_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/TilesetReader/TilesetMerger.py
+++ b/py3dtilers/TilesetReader/TilesetMerger.py
@@ -97,7 +97,7 @@ class TilesetMerger():
             Path(target_dir).mkdir(parents=True, exist_ok=True)
 
             self.copy_tileset_texture_images(tileset, tileset_of_root_tiles)
-            tileset.write_to_directory(self.output_path)
+            tileset.write_as_json(self.output_path)
 
 
 def main():

--- a/py3dtilers/TilesetReader/TilesetReader.py
+++ b/py3dtilers/TilesetReader/TilesetReader.py
@@ -41,23 +41,6 @@ class TilesetTiler(Tiler):
         """
         Override the parent tileset creation.
         """
-        if hasattr(self.args, 'scale') and self.args.scale:
-            for objects in tileset_tree.get_all_objects():
-                objects.scale_features(self.args.scale)
-
-        if not all(v == 0 for v in self.args.offset) or self.args.offset[0] == 'centroid':
-            if self.args.offset[0] == 'centroid':
-                self.args.offset = tileset_tree.get_centroid()
-            for objects in tileset_tree.get_all_objects():
-                objects.translate_features(self.args.offset)
-
-        if not self.args.crs_in == self.args.crs_out:
-            for objects in tileset_tree.get_all_objects():
-                self.change_projection(objects, self.args.crs_in, self.args.crs_out)
-
-        if self.args.obj is not None:
-            self.write_geometries_as_obj(tileset_tree.get_leaf_objects(), self.args.obj)
-
         self.create_output_directory()
         return FromGeometryTreeToTileset.convert_to_tileset(tileset_tree, extension_name)
 
@@ -70,7 +53,7 @@ class TilesetTiler(Tiler):
         :return: a TileSet
         """
         tileset_tree = TilesetTree(tileset, self.tileset_of_root_tiles)
-        return self.create_tileset_from_geometries(tileset_tree)
+        return self.create_tileset_from_geometries(tileset_tree, self.args)
 
     def read_and_merge_tilesets(self, paths_to_tilesets=list()):
         """

--- a/py3dtilers/TilesetReader/TilesetReader.py
+++ b/py3dtilers/TilesetReader/TilesetReader.py
@@ -42,7 +42,7 @@ class TilesetTiler(Tiler):
         Override the parent tileset creation.
         """
         self.create_output_directory()
-        return FromGeometryTreeToTileset.convert_to_tileset(tileset_tree, extension_name)
+        return FromGeometryTreeToTileset.convert_to_tileset(tileset_tree, self.args, extension_name, self.get_output_dir())
 
     def transform_tileset(self, tileset):
         """
@@ -76,7 +76,7 @@ def main():
     tileset = tiler.read_and_merge_tilesets(tiler.args.paths)
 
     tileset = tiler.transform_tileset(tileset)
-    tileset.write_to_directory(tiler.get_output_dir())
+    tileset.write_as_json(tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -48,7 +48,7 @@ class Test_Tile(unittest.TestCase):
 
         [cursor.close() for cursor in cursors]
 
-        tile_set.write_to_directory(output_dir)
+        tile_set.write_as_json(output_dir)
 
 
 if __name__ == '__main__':

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -22,7 +22,7 @@ class Test_Tile(unittest.TestCase):
     def test_temporal(self):
         city_temp_tiler = CityTemporalTiler()
         output_dir = Path("tests/city_temporal_tiler_test_data/generated_tilesets/temporal")
-        city_temp_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=output_dir)
+        city_temp_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=output_dir, split_surfaces=False)
         cli_args = Args()
         graph = TemporalGraph(cli_args)
         graph.reconstruct_connectivity()

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -22,7 +22,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_water_basic_case(self):
@@ -35,7 +35,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_relief_basic_case(self):
@@ -48,7 +48,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_building_lod1(self):
@@ -61,7 +61,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_building_loa(self):
@@ -74,7 +74,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_building_loa_lod1(self):
@@ -87,7 +87,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_building_BTH(self):
@@ -101,7 +101,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         CityMBuildings.with_bth = False
         cursor.close()
 
@@ -115,7 +115,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_relief_split_surface(self):
@@ -128,7 +128,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_water_split_surface(self):
@@ -141,7 +141,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_building_texture(self):
@@ -154,7 +154,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_relief_texture(self):
@@ -167,7 +167,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_bridge(self):
@@ -180,7 +180,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
     def test_bridge_split_surface(self):
@@ -193,7 +193,7 @@ class Test_Tile(unittest.TestCase):
         city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
 

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -19,7 +19,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -32,7 +32,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMWaterBodies
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -45,7 +45,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -58,7 +58,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -71,7 +71,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -84,7 +84,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -98,7 +98,7 @@ class Test_Tile(unittest.TestCase):
         CityMBuildings.set_bth()
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -112,8 +112,8 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
-        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
         cursor.close()
@@ -125,8 +125,8 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
-        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
         cursor.close()
@@ -138,8 +138,8 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMWaterBodies
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
-        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
         cursor.close()
@@ -151,7 +151,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -164,7 +164,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -177,7 +177,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBridges
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
@@ -190,8 +190,8 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBridges
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
-        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_to_directory(directory)
         cursor.close()

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -17,7 +17,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_properties_with_other_name(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
@@ -29,7 +29,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_default_height(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
@@ -41,7 +41,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_z(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
@@ -53,7 +53,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_no_height(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
@@ -65,7 +65,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_add_color(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
@@ -77,7 +77,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True, color_attribute=('HAUTEUR', 'numeric'))
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_create_loa(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
@@ -88,7 +88,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=None, loa='tests/geojson_tiler_test_data/polygons/', lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_create_lod1(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
@@ -99,7 +99,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_create_lod1_and_loa(self):
         path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
@@ -110,7 +110,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=None, loa='tests/geojson_tiler_test_data/polygons/', lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_line_string(self):
         path = Path('tests/geojson_tiler_test_data/roads/line_string_road.geojson')
@@ -122,7 +122,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=False)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
     def test_multi_line_string(self):
         path = Path('tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson')
@@ -134,7 +134,7 @@ class Test_Tile(unittest.TestCase):
         geojson_tiler.args = Namespace(obj=obj_name, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
         tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=False)
         if(tileset is not None):
-            tileset.write_to_directory(directory)
+            tileset.write_as_json(directory)
 
 
 if __name__ == '__main__':

--- a/tests/test_objTiler.py
+++ b/tests/test_objTiler.py
@@ -16,7 +16,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = obj_tiler.from_obj_directory(path)
         if(tileset is not None):
-            tileset.write_to_directory(Path("tests/obj_tiler_data/generated_tilesets/", obj_tiler.current_path))
+            tileset.write_as_json(Path("tests/obj_tiler_data/generated_tilesets/", obj_tiler.current_path))
 
     def test_texture(self):
         path = Path('tests/obj_tiler_data/TexturedCube')
@@ -28,7 +28,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = obj_tiler.from_obj_directory(path)
         if(tileset is not None):
-            tileset.write_to_directory(Path("tests/obj_tiler_data/generated_tilesets/", obj_tiler.current_path))
+            tileset.write_as_json(Path("tests/obj_tiler_data/generated_tilesets/", obj_tiler.current_path))
 
 
 if __name__ == '__main__':

--- a/tests/test_tiler.py
+++ b/tests/test_tiler.py
@@ -45,7 +45,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_lod1(self):
         feature = Feature("lod1")
@@ -59,7 +59,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_loa(self):
         feature = Feature("loa")
@@ -73,7 +73,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_change_crs(self):
         feature = Feature("change_crs")
@@ -87,7 +87,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_offset(self):
         feature = Feature("offset")
@@ -101,7 +101,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_offset_centroid(self):
         feature = Feature("offset_centroid")
@@ -115,7 +115,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_scale(self):
         feature = Feature("scale")
@@ -129,7 +129,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
     def test_obj(self):
         feature = Feature("scale")
@@ -145,7 +145,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
 
 
 if __name__ == '__main__':

--- a/tests/test_tilesetReader.py
+++ b/tests/test_tilesetReader.py
@@ -16,7 +16,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.read_and_merge_tilesets(paths)
         tileset = tiler.transform_tileset(tileset)
-        tileset.write_to_directory(output_dir)
+        tileset.write_as_json(output_dir)
 
     def test_merge(self):
         tiler = TilesetTiler()
@@ -26,7 +26,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.read_and_merge_tilesets(paths)
         tileset = tiler.transform_tileset(tileset)
-        tileset.write_to_directory(output_dir)
+        tileset.write_as_json(output_dir)
 
     def test_transform(self):
         tiler = TilesetTiler()
@@ -36,7 +36,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.read_and_merge_tilesets(paths)
         tileset = tiler.transform_tileset(tileset)
-        tileset.write_to_directory(output_dir)
+        tileset.write_as_json(output_dir)
 
     def test_obj(self):
         tiler = TilesetTiler()
@@ -47,7 +47,7 @@ class Test_Tile(unittest.TestCase):
 
         tileset = tiler.read_and_merge_tilesets(paths)
         tileset = tiler.transform_tileset(tileset)
-        tileset.write_to_directory(output_dir)
+        tileset.write_as_json(output_dir)
 
     def test_merger(self):
         merger = TilesetMerger(output_path="tests/tileset_reader_test_data/generated_tilesets/merger/")


### PR DESCRIPTION
Create and write the tileset tile by tile. Each tile is transformed (reprojected, translated, etc) separately. Once a tile is created, its content (.b3dm) is writen on the disk and deleted from the memory.

Also, the CityTiler now loads the geometries of the features tile by tile. The distribution of the features into tiles can be done with only the centroid of each feature. When dealing with huge amount of data, loading only the triangles of the current tile drastically reduce the memory usage.

This PR also comes with a rework of the LODs creation. The objectives were to:
- Create the LODs tile by tile (and not before the tileset creation)
- Clarify the LOA creation

See [issue](https://github.com/VCityTeam/py3dtilers/issues/58) for more details

_Note_: py3dtiles needs to be uninstalled and reinstalled, else the `write_as_json` method of the TileSet class won't be found.