### PR TITLE
CityTiler with colors

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -43,6 +43,11 @@ class CityTiler(Tiler):
                                  action='store_true',
                                  help='Keeps the surfaces of the cityObjects split when defined')
 
+        self.parser.add_argument('--add_color',
+                                 dest='add_color',
+                                 action='store_true',
+                                 help='When defined, add colors to the features depending on their CityGML objectclass.')
+
     def get_output_dir(self):
         """
         Return the directory name for the tileset.

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -94,6 +94,22 @@ To create the BatchTableHierarchy extension:
 citygml-tiler --db_config_path <path_to_file>/Config.yml --with_BTH
 ```
 
+### Color
+
+When present, the `--add_color` flag adds a single colored material to each feature. The color of the material is determined by CityGML `objectclass` of each feature.  
+
+```bash
+citygml-tiler --db_config_path <path_to_file>/Config.yml --add_color
+```
+
+If you want to apply different colors on the surfaces of buildings (roof, wall and floor), use the `--split_surfaces` flag:
+
+```bash
+citygml-tiler --db_config_path <path_to_file>/Config.yml --add_color --split_surfaces
+```
+
+The default colors are defined by a [JSON file](../Color/citytiler_config.json). If you want to change the colors used, update the file with the right color codes. (__See [Color module](../Color/README.md#colordict) for more details__)
+
 ## CityTemporalTiler features
 
 The City Temporal Tiler creates tilesets with a __temporal extension__. This extension allows to visualize the evolution of buildings through time.

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -108,7 +108,7 @@ If you want to apply different colors on the surfaces of buildings (roof, wall a
 citygml-tiler --db_config_path <path_to_file>/Config.yml --add_color --split_surfaces
 ```
 
-The default colors are defined by a [JSON file](../Color/citytiler_config.json). If you want to change the colors used, update the file with the right color codes. (__See [Color module](../Color/README.md#colordict) for more details__)
+The default colors are defined by a [JSON file](../Color/citytiler_config.json). If you want to change the colors used, update the file with the right color codes. (__See [Color module](../Color/README.md#color_dict) for more details__)
 
 ## CityTemporalTiler features
 

--- a/py3dtilers/CityTiler/citym_bridge.py
+++ b/py3dtilers/CityTiler/citym_bridge.py
@@ -66,10 +66,11 @@ class CityMBridges(CityMCityObjects):
         if split_surfaces:
             query = \
                 "SELECT surface_geometry.id, ST_AsBinary(ST_Multi( " + \
-                "surface_geometry.geometry) " + \
-                ") " + \
+                "surface_geometry.geometry)), " + \
+                "objectclass.classname " + \
                 "FROM citydb.surface_geometry JOIN citydb.bridge " + \
                 "ON surface_geometry.root_id=bridge.lod2_multi_surface_id " + \
+                "JOIN citydb.objectclass ON bridge.objectclass_id = objectclass.id " + \
                 "WHERE bridge.bridge_root_id IN " + bridges_ids_arg
         else:
             query = \

--- a/py3dtilers/CityTiler/citym_bridge.py
+++ b/py3dtilers/CityTiler/citym_bridge.py
@@ -75,12 +75,13 @@ class CityMBridges(CityMCityObjects):
         else:
             query = \
                 "SELECT bridge.bridge_root_id, ST_AsBinary(ST_Multi(ST_Collect( " + \
-                "surface_geometry.geometry) " + \
-                ")) " + \
+                "surface_geometry.geometry))), " + \
+                "objectclass.classname " + \
                 "FROM citydb.surface_geometry JOIN citydb.bridge " + \
                 "ON surface_geometry.root_id=bridge.lod2_multi_surface_id " + \
+                "JOIN citydb.objectclass ON bridge.objectclass_id = objectclass.id " + \
                 "WHERE bridge.bridge_root_id IN " + bridges_ids_arg + " " + \
-                "GROUP BY bridge.bridge_root_id "
+                "GROUP BY bridge.bridge_root_id, objectclass.classname"
 
         return query
 

--- a/py3dtilers/CityTiler/citym_building.py
+++ b/py3dtilers/CityTiler/citym_building.py
@@ -105,13 +105,14 @@ class CityMBuildings(CityMCityObjects):
         else:
             query = \
                 "SELECT building.building_root_id, ST_AsBinary(ST_Multi(ST_Collect( " + \
-                "surface_geometry.geometry) " + \
-                ")) " + \
+                "surface_geometry.geometry))), " + \
+                "objectclass.classname " + \
                 "FROM citydb.surface_geometry JOIN citydb.thematic_surface " + \
                 "ON surface_geometry.root_id=thematic_surface.lod2_multi_surface_id " + \
                 "JOIN citydb.building ON thematic_surface.building_id = building.id " + \
+                "JOIN citydb.objectclass ON building.objectclass_id = objectclass.id " + \
                 "WHERE building.building_root_id IN " + buildings_ids_arg + " " + \
-                "GROUP BY building.building_root_id "
+                "GROUP BY building.building_root_id, objectclass.classname"
 
         return query
 

--- a/py3dtilers/CityTiler/citym_building.py
+++ b/py3dtilers/CityTiler/citym_building.py
@@ -95,11 +95,12 @@ class CityMBuildings(CityMCityObjects):
         if split_surfaces:
             query = \
                 "SELECT surface_geometry.id, ST_AsBinary(ST_Multi( " + \
-                "surface_geometry.geometry) " + \
-                ") " + \
+                "surface_geometry.geometry)), " + \
+                "objectclass.classname " + \
                 "FROM citydb.surface_geometry JOIN citydb.thematic_surface " + \
                 "ON surface_geometry.root_id=thematic_surface.lod2_multi_surface_id " + \
                 "JOIN citydb.building ON thematic_surface.building_id = building.id " + \
+                "JOIN citydb.objectclass ON thematic_surface.objectclass_id = objectclass.id " + \
                 "WHERE building.building_root_id IN " + buildings_ids_arg
         else:
             query = \

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -82,12 +82,12 @@ class CityMCityObject(Feature):
                         texture_uri = t[3]
                         cityobject.texture_uri = texture_uri
                         associated_data = [uv_as_string]
-
-                    if surface_classname not in material_indexes:
-                        material = feature_list.get_color_config().get_color_by_key(surface_classname)
-                        material_indexes[surface_classname] = len(feature_list.materials)
-                        feature_list.add_materials([material])
-                    cityobject.material_index = material_indexes[surface_classname]
+                    elif user_arguments.add_color:
+                        if surface_classname not in material_indexes:
+                            material = feature_list.get_color_config().get_color_by_key(surface_classname)
+                            material_indexes[surface_classname] = len(feature_list.materials)
+                            feature_list.add_materials([material])
+                        cityobject.material_index = material_indexes[surface_classname]
 
                     cityobject.geom = TriangleSoup.from_wkb_multipolygon(geom_as_string, associated_data)
                     if len(cityobject.geom.triangles[0]) > 0:

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -72,7 +72,6 @@ class CityMCityObject(Feature):
             try:
                 feature_id = t[0]
                 geom_as_string = t[1]
-                surface_classname = t[2]
                 if geom_as_string is not None:
                     cityobject = self.__class__(feature_id, self.get_gml_id())
                     associated_data = []
@@ -83,6 +82,7 @@ class CityMCityObject(Feature):
                         cityobject.texture_uri = texture_uri
                         associated_data = [uv_as_string]
                     elif user_arguments.add_color:
+                        surface_classname = t[2]
                         if surface_classname not in material_indexes:
                             material = feature_list.get_color_config().get_color_by_key(surface_classname)
                             material_indexes[surface_classname] = len(feature_list.materials)
@@ -136,6 +136,8 @@ class CityMCityObjects(FeatureList):
         """
         features_with_geom = list()
         material_indexes = dict()
+        if user_arguments.add_color:
+            self.materials = list()
         for feature in self.objects:
             features_with_geom.extend(feature.get_geom(user_arguments, self, material_indexes))
         self.objects = features_with_geom

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from io import BytesIO
 from py3dtiles import TriangleSoup
+import os
 
 from ..Common import Feature, FeatureList
 from ..Texture import Texture
@@ -101,6 +102,9 @@ class CityMCityObjects(FeatureList):
     gml_cursor = None
 
     def __init__(self, cityMCityObjects=None):
+        if self.color_config is None:
+            config_path = os.path.join(os.path.dirname(__file__), ".." , "Color", "citytiler_config.json")
+            self.set_color_config(config_path)
         super().__init__(cityMCityObjects)
 
     def get_textures(self):

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -110,7 +110,7 @@ class CityMCityObjects(FeatureList):
 
     def __init__(self, cityMCityObjects=None):
         if self.color_config is None:
-            config_path = os.path.join(os.path.dirname(__file__), ".." , "Color", "citytiler_config.json")
+            config_path = os.path.join(os.path.dirname(__file__), "..", "Color", "citytiler_config.json")
             self.set_color_config(config_path)
         super().__init__(cityMCityObjects)
 

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -129,19 +129,6 @@ class CityMCityObjects(FeatureList):
             texture_dict[feature.get_id()] = uri_dict[uri].get_cropped_texture_image(feature.geom.triangles[1])
         return texture_dict
 
-    def set_features_geom(self, user_arguments=None):
-        """
-        Set the geometry of the features.
-        Keep only the features with geometry.
-        """
-        features_with_geom = list()
-        material_indexes = dict()
-        if user_arguments.add_color:
-            self.materials = list()
-        for feature in self.objects:
-            features_with_geom.extend(feature.get_geom(user_arguments, self, material_indexes))
-        self.objects = features_with_geom
-
     @staticmethod
     def set_cursor(cursor):
         """

--- a/py3dtilers/CityTiler/citym_relief.py
+++ b/py3dtilers/CityTiler/citym_relief.py
@@ -75,12 +75,14 @@ class CityMReliefs(CityMCityObjects):
         # cityobjects_ids contains ids of reliefs
         if split_surfaces:
             query = \
-                "SELECT relief_feature.id, ST_AsBinary(ST_Multi(surface_geometry.geometry)) " + \
+                "SELECT relief_feature.id, ST_AsBinary(ST_Multi(surface_geometry.geometry)), " + \
+                "objectclass.classname " + \
                 "FROM citydb.relief_feature JOIN citydb.relief_feat_to_rel_comp " + \
                 "ON relief_feature.id=relief_feat_to_rel_comp.relief_feature_id " + \
                 "JOIN citydb.tin_relief " + \
                 "ON relief_feat_to_rel_comp.relief_component_id=tin_relief.id " + \
                 "JOIN citydb.surface_geometry ON surface_geometry.root_id=tin_relief.surface_geometry_id " + \
+                "JOIN citydb.objectclass ON relief_feature.objectclass_id = objectclass.id " + \
                 "WHERE relief_feature.id IN " + reliefs_ids
         else:
             query = \

--- a/py3dtilers/CityTiler/citym_relief.py
+++ b/py3dtilers/CityTiler/citym_relief.py
@@ -86,14 +86,16 @@ class CityMReliefs(CityMCityObjects):
                 "WHERE relief_feature.id IN " + reliefs_ids
         else:
             query = \
-                "SELECT relief_feature.id, ST_AsBinary(ST_Multi(ST_Collect(surface_geometry.geometry))) " + \
+                "SELECT relief_feature.id, ST_AsBinary(ST_Multi(ST_Collect(surface_geometry.geometry))), " + \
+                "objectclass.classname " + \
                 "FROM citydb.relief_feature JOIN citydb.relief_feat_to_rel_comp " + \
                 "ON relief_feature.id=relief_feat_to_rel_comp.relief_feature_id " + \
                 "JOIN citydb.tin_relief " + \
                 "ON relief_feat_to_rel_comp.relief_component_id=tin_relief.id " + \
                 "JOIN citydb.surface_geometry ON surface_geometry.root_id=tin_relief.surface_geometry_id " + \
+                "JOIN citydb.objectclass ON relief_feature.objectclass_id = objectclass.id " + \
                 "WHERE relief_feature.id IN " + reliefs_ids + " " + \
-                "GROUP BY relief_feature.id "
+                "GROUP BY relief_feature.id, objectclass.classname"
 
         return query
 

--- a/py3dtilers/CityTiler/citym_waterbody.py
+++ b/py3dtilers/CityTiler/citym_waterbody.py
@@ -86,14 +86,16 @@ class CityMWaterBodies(CityMCityObjects):
                 "WHERE waterbody.id IN " + waterbodies_ids
         else:
             query = \
-                "SELECT waterbody.id, ST_AsBinary(ST_Multi(ST_Collect(surface_geometry.geometry))) " + \
+                "SELECT waterbody.id, ST_AsBinary(ST_Multi(ST_Collect(surface_geometry.geometry))), " + \
+                "objectclass.classname " + \
                 "FROM citydb.waterbody JOIN citydb.waterbod_to_waterbnd_srf " + \
                 "ON waterbody.id=waterbod_to_waterbnd_srf.waterbody_id " + \
                 "JOIN citydb.waterboundary_surface " + \
                 "ON waterbod_to_waterbnd_srf.waterboundary_surface_id=waterboundary_surface.id " + \
                 "JOIN citydb.surface_geometry ON surface_geometry.root_id=waterboundary_surface.lod3_surface_id " + \
+                "JOIN citydb.objectclass ON waterbody.objectclass_id = objectclass.id " + \
                 "WHERE waterbody.id IN " + waterbodies_ids + " " + \
-                "GROUP BY waterbody.id "
+                "GROUP BY waterbody.id, objectclass.classname"
 
         return query
 

--- a/py3dtilers/CityTiler/citym_waterbody.py
+++ b/py3dtilers/CityTiler/citym_waterbody.py
@@ -75,12 +75,14 @@ class CityMWaterBodies(CityMCityObjects):
         # cityobjects_ids contains ids of waterbodies
         if split_surfaces:
             query = \
-                "SELECT waterbody.id, ST_AsBinary(ST_Multi(surface_geometry.geometry)) " + \
+                "SELECT waterbody.id, ST_AsBinary(ST_Multi(surface_geometry.geometry)), " + \
+                "objectclass.classname " + \
                 "FROM citydb.waterbody JOIN citydb.waterbod_to_waterbnd_srf " + \
                 "ON waterbody.id=waterbod_to_waterbnd_srf.waterbody_id " + \
                 "JOIN citydb.waterboundary_surface " + \
                 "ON waterbod_to_waterbnd_srf.waterboundary_surface_id=waterboundary_surface.id " + \
                 "JOIN citydb.surface_geometry ON surface_geometry.root_id=waterboundary_surface.lod3_surface_id " + \
+                "JOIN citydb.objectclass ON waterboundary_surface.objectclass_id = objectclass.id " + \
                 "WHERE waterbody.id IN " + waterbodies_ids
         else:
             query = \

--- a/py3dtilers/CityTiler/temporal_building.py
+++ b/py3dtilers/CityTiler/temporal_building.py
@@ -40,7 +40,7 @@ class TemporalBuilding(CityMBuilding):
         # This should be of type date and by default is manipulated as string:
         return self.temporal_id.split('::')[0]
 
-    def get_geom(self, user_arguments=None):
+    def get_geom(self, user_arguments=None, feature_list=None, material_indexes=dict):
         """
         Get the geometry of the feature.
         :return: a boolean

--- a/py3dtilers/Color/citytiler_config.json
+++ b/py3dtilers/Color/citytiler_config.json
@@ -1,0 +1,10 @@
+{
+    "default_color": [0, 0, 0],
+
+    "color_dict": {
+        "BuildingRoofSurface": [1, 0, 0],
+        "BuildingWallSurface": [0, 0, 1],
+        "BuildingGroundSurface": [0, 1, 0],
+        "default": [0.5, 0.5, 0.5]
+    }
+}

--- a/py3dtilers/Color/citytiler_config.json
+++ b/py3dtilers/Color/citytiler_config.json
@@ -1,10 +1,13 @@
 {
-    "default_color": [0, 0, 0],
+    "default_color": [1, 1, 1],
 
     "color_dict": {
-        "BuildingRoofSurface": [1, 0, 0],
-        "BuildingWallSurface": [0, 0, 1],
-        "BuildingGroundSurface": [0, 1, 0],
-        "default": [0.5, 0.5, 0.5]
+        "BuildingRoofSurface": "#da7f20",
+        "BuildingWallSurface": [1, 1, 1],
+        "BuildingGroundSurface": [1, 1, 1],
+        "WaterSurface": "#3d85c6",
+        "Bridge": [0, 0, 0],
+        "ReliefFeature": "#e2ca86",
+        "default": [1, 1, 1]
     }
 }

--- a/py3dtilers/Color/citytiler_config.json
+++ b/py3dtilers/Color/citytiler_config.json
@@ -5,7 +5,9 @@
         "BuildingRoofSurface": "#da7f20",
         "BuildingWallSurface": [1, 1, 1],
         "BuildingGroundSurface": [1, 1, 1],
+        "Building": [1, 1, 1],
         "WaterSurface": "#3d85c6",
+        "WaterBody": "#3d85c6",
         "Bridge": [0, 0, 0],
         "ReliefFeature": "#e2ca86",
         "default": [1, 1, 1]

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -120,7 +120,7 @@ class Feature(object):
         """
         return self.texture is not None
 
-    def get_geom(self, user_arguments=None):
+    def get_geom(self, user_arguments=None, feature_list=None, material_indexes=dict()):
         """
         Get the geometry of the feature.
         :return: a boolean
@@ -293,8 +293,9 @@ class FeatureList(object):
         Keep only the features with geometry.
         """
         features_with_geom = list()
+        material_indexes = dict()
         for feature in self.objects:
-            features_with_geom.extend(feature.get_geom(user_arguments))
+            features_with_geom.extend(feature.get_geom(user_arguments, self, material_indexes))
         self.objects = features_with_geom
 
     @classmethod

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -302,9 +302,9 @@ class FeatureList(object):
         """
         Set the ColorConfig from a JSON file.
         The ColorConfig is used to created colored materials.
-        :param config_path: path to the JSON file 
+        :param config_path: path to the JSON file
         """
-        ObjectsToTile.color_config = ColorConfig(config_path)
+        FeatureList.color_config = ColorConfig(config_path)
 
     @classmethod
     def get_color_config(cls):
@@ -312,9 +312,9 @@ class FeatureList(object):
         Return the ColorConfig used to created colored materials.
         :return: a ColorConfig
         """
-        if ObjectsToTile.color_config is None:
-            ObjectsToTile.color_config = ColorConfig()
-        return ObjectsToTile.color_config
+        if FeatureList.color_config is None:
+            FeatureList.color_config = ColorConfig()
+        return FeatureList.color_config
 
     @staticmethod
     def create_batch_table_extension(extension_name, ids=None, objects=None):

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -136,13 +136,15 @@ class FeatureList(object):
     A decorated list of FeatureList type objects.
     """
 
-    # The material used by default for features
+    # The color config used to create colored materials
+    color_config = None
+    # The material used by default for geometries
     default_mat = None
 
     def __init__(self, objects=None):
         self.objects = list()
         if FeatureList.default_mat is None:
-            FeatureList.default_mat = ColorConfig().get_default_color()
+            FeatureList.default_mat = self.get_color_config().get_default_color()
         self.materials = [FeatureList.default_mat]
         if(objects):
             self.objects.extend(objects)
@@ -294,6 +296,25 @@ class FeatureList(object):
         for feature in self.objects:
             features_with_geom.extend(feature.get_geom(user_arguments))
         self.objects = features_with_geom
+
+    @classmethod
+    def set_color_config(cls, config_path):
+        """
+        Set the ColorConfig from a JSON file.
+        The ColorConfig is used to created colored materials.
+        :param config_path: path to the JSON file 
+        """
+        ObjectsToTile.color_config = ColorConfig(config_path)
+
+    @classmethod
+    def get_color_config(cls):
+        """
+        Return the ColorConfig used to created colored materials.
+        :return: a ColorConfig
+        """
+        if ObjectsToTile.color_config is None:
+            ObjectsToTile.color_config = ColorConfig()
+        return ObjectsToTile.color_config
 
     @staticmethod
     def create_batch_table_extension(extension_name, ids=None, objects=None):

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -127,20 +127,20 @@ class FromGeometryTreeToTileset():
         # create B3DM content
         arrays = []
         materials = []
-        seen_mat_indexes = []
+        seen_mat_indexes = dict()
         if with_texture:
             tile_atlas = Atlas(objects)
             objects.set_materials([GlTFMaterial(textureUri='./ATLAS_' + str(tile_atlas.tile_number) + '.png')])
         for feature in objects:
             mat_index = feature.material_index
             if mat_index not in seen_mat_indexes:
-                seen_mat_indexes.append(mat_index)
+                seen_mat_indexes[mat_index] = len(materials)
                 materials.append(objects.get_material(mat_index))
             content = {
                 'position': feature.geom.getPositionArray(),
                 'normal': feature.geom.getNormalArray(),
                 'bbox': [[float(i) for i in j] for j in feature.geom.getBbox()],
-                'matIndex': mat_index
+                'matIndex': seen_mat_indexes[mat_index]
             }
             if with_texture:
                 content['uv'] = feature.geom.getDataArray(0)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = (
     'scipy',
     'shapely',
     'alphashape',
-    'py3dtiles @ git+https://github.com/VCityTeam/py3dtiles@batched_in_different_meshes',
+    'py3dtiles @ git+https://github.com/VCityTeam/py3dtiles@Tiler',
     'earclip @ git+https://github.com/lionfish0/earclip',
     'Pillow'
     # 'ifcopenshell' requires specific treatment, refer to

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = (
     'scipy',
     'shapely',
     'alphashape',
-    'py3dtiles @ git+https://github.com/VCityTeam/py3dtiles@Tiler',
+    'py3dtiles @ git+https://github.com/VCityTeam/py3dtiles@batched_in_different_meshes',
     'earclip @ git+https://github.com/lionfish0/earclip',
     'Pillow'
     # 'ifcopenshell' requires specific treatment, refer to

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,9 @@ setup(
                  ),
                 ('py3dtilers/Color',
                  ['py3dtilers/Color/default_config.json']
+                ),
+                ('py3dtilers/Color',
+                 ['py3dtilers/Color/citytiler_config.json']
                 )],
     zip_safe=False  # zip packaging conflicts with Numba cache (#25)
 )

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -22,7 +22,7 @@ class Test_Tile(unittest.TestCase):
     def test_temporal(self):
         city_temp_tiler = CityTemporalTiler()
         output_dir = Path("tests/city_temporal_tiler_test_data/generated_tilesets/temporal")
-        city_temp_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=output_dir, split_surfaces=False)
+        city_temp_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=output_dir, split_surfaces=False, add_color=False)
         cli_args = Args()
         graph = TemporalGraph(cli_args)
         graph.reconstruct_connectivity()

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -203,10 +203,10 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
-        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True, add_color=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True, add_color=True)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
-        tileset.write_to_directory(directory)
+        tileset.write_as_json(directory)
         cursor.close()
 
 

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -19,7 +19,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -32,7 +32,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMWaterBodies
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -45,7 +45,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -58,7 +58,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -71,7 +71,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -84,7 +84,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa="tests/city_tiler_test_data/polygons", lod1=True, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -98,7 +98,7 @@ class Test_Tile(unittest.TestCase):
         CityMBuildings.set_bth()
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -112,7 +112,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -125,7 +125,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -138,7 +138,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMWaterBodies
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -151,7 +151,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBuildings
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -164,7 +164,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMReliefs
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=True, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -177,7 +177,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBridges
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=False, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)
@@ -190,7 +190,7 @@ class Test_Tile(unittest.TestCase):
         objects_type = CityMBridges
         objects_type.set_cursor(cursor)
         city_tiler = CityTiler()
-        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True)
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory, split_surfaces=True, add_color=False)
         tileset = city_tiler.from_3dcitydb(cursor, objects_type)
 
         tileset.write_as_json(directory)

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -196,6 +196,19 @@ class Test_Tile(unittest.TestCase):
         tileset.write_as_json(directory)
         cursor.close()
 
+    def test_building_color(self):
+
+        directory = Path("tests/city_tiler_test_data/junk/building_color")
+        cursor = open_data_base(Path("tests/city_tiler_test_data/test_config.yml"))
+        objects_type = CityMBuildings
+        objects_type.set_cursor(cursor)
+        city_tiler = CityTiler()
+        city_tiler.args = Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946', crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, output_dir=directory)
+        tileset = city_tiler.from_3dcitydb(cursor, objects_type, split_surfaces=True, add_color=True)
+
+        tileset.write_to_directory(directory)
+        cursor.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The CityTiler can add colors on the 3DTiles depending on the CityGML class of the features.

The colors are defined in a JSON file. The colors can be applied on the CityObject level (one color for a whole building, bridge, etc) or on the surface level (one color for the walls, one for the roof, etc).

Usage:

```bash
citygml-tiler --add_color  # Will apply colors on CityObject level  
```

```bash
citygml-tiler --add_color --split_surfaces # Will apply colors on surface level  
```

![city_tiler_colors](https://user-images.githubusercontent.com/32875283/159442483-f80c6755-2792-4856-b098-f8ffec20a681.png)
 