### PR TITLE
Set kd-tree max in command line

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -66,6 +66,17 @@ class CityTiler(Tiler):
         else:
             return self.args.output_dir
 
+    def get_kd_tree_max(self):
+        """
+        The kd_tree_max is the maximum number of features in each tile when the features are distributed by a kd-tree.
+        If the user has specified a value for the kd_tree_max argument, use that value. Otherwise, use the
+        default value.
+        :return: a int
+        """
+        if self.args.kd_tree_max is not None and self.args.kd_tree_max > 0:
+            return self.args.kd_tree_max
+        return int(self.DEFAULT_KD_TREE_MAX / 20) if self.args.with_texture else self.DEFAULT_KD_TREE_MAX
+
     def set_features_centroid(self, cursor, cityobjects, objects_type):
         """
         Get the surfaces of all the cityobjects and transform them into TriangleSoup.
@@ -107,11 +118,10 @@ class CityTiler(Tiler):
 
         self.set_features_centroid(cursor, cityobjects, objects_type)
 
-        kd_tree_max = 25 if self.args.with_texture else 500
         extension_name = None
         if CityMBuildings.is_bth_set():
             extension_name = "batch_table_hierarchy"
-        return self.create_tileset_from_geometries(cityobjects, extension_name=extension_name, kd_tree_max=kd_tree_max)
+        return self.create_tileset_from_geometries(cityobjects, extension_name=extension_name)
 
 
 def main():

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -148,6 +148,8 @@ Read the texture from the input and write it in the produced 3DTiles:
 <tiler> <input> --with_texture
 ```
 
+_Note: if your texture images are too heavy, consider using [`--kd_tree_max` option](#kd-tree-max)._
+
 ### Geometric error
 
 | Tiler | |

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -178,6 +178,22 @@ You can skip leaf tiles and their parents geometric errors by writing a non nume
 tileset-reader --paths <tileset_path> --geometric_error x x 100  # Set root tiles GE to 100
 ```
 
+### Kd-tree max
+
+| Tiler | |
+| --- | --- |
+| CityTiler | :heavy_check_mark: |
+| ObjTiler | :heavy_check_mark: |
+| GeojsonTiler | :heavy_check_mark: |
+| IfcTiler | :heavy_check_mark: |
+| TilesetTiler | :heavy_check_mark: |
+
+`--kd_tree_max` allows to choose the maximum number of features in each tile when the features are distributed by a kd-tree. The flag must be followed by an __integer__. By default, each tile contains a maximum of 500 features.
+
+```bash
+<tiler> <input> --kd_tree_max 25
+```
+
 ## __Developper notes__
 
 ## [feature](feature.py)

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -190,8 +190,10 @@ tileset-reader --paths <tileset_path> --geometric_error x x 100  # Set root tile
 
 `--kd_tree_max` allows to choose the maximum number of features in each tile when the features are distributed by a kd-tree. The flag must be followed by an __integer__. By default, each tile contains a maximum of 500 features.
 
+When using the CityTiler [with texture](#with-texture), the default maximum of features per tile is divided by __20__ in order to reduce the size of texture atlases. If a tile contains too much textured features, its atlas may be to heavy in memory, so consider choosing a `kd_tree_max` according to the resolution/size of the texture images.
+
 ```bash
-<tiler> <input> --kd_tree_max 25
+<tiler> <input> --kd_tree_max 25  # Each tile will contain a maximum of 25 features 
 ```
 
 ## __Developper notes__

--- a/py3dtilers/Common/kd_tree.py
+++ b/py3dtilers/Common/kd_tree.py
@@ -32,7 +32,7 @@ def kd_tree(feature_list, maxNumObjects, depth=0):
     lObjects = feature_list[:median]
     rObjects = feature_list[median:]
     pre_tiles = derived()
-    if len(lObjects) > maxNumObjects:
+    if len(lObjects) > maxNumObjects or len(rObjects) > maxNumObjects:
         pre_tiles.extend(kd_tree(lObjects, maxNumObjects, depth + 1))
         pre_tiles.extend(kd_tree(rObjects, maxNumObjects, depth + 1))
     else:

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -8,6 +8,9 @@ from ..Texture import Texture
 
 class Tiler():
 
+    # The kd_tree_max is the maximum number of features that the kd-tree will put in each tile.
+    DEFAULT_KD_TREE_MAX = 500
+
     def __init__(self):
         text = '''A small utility that build a 3DTiles tileset out of data'''
         self.parser = argparse.ArgumentParser(description=text)
@@ -70,6 +73,12 @@ class Tiler():
                                  help='The geometric errors of the nodes.\
                                      Used (from left ro right) for basic nodes, LOD1 nodes and LOA nodes.')
 
+        self.parser.add_argument('--kd_tree_max',
+                                 nargs='?',
+                                 type=int,
+                                 help='Set the maximum number of features in each tile when the features are distributed by a kd-tree.\
+                                     The value must be an integer.')
+
     def parse_command_line(self):
         self.args = self.parser.parse_args()
 
@@ -97,6 +106,18 @@ class Tiler():
         else:
             return self.args.output_dir
 
+    def get_kd_tree_max(self):
+        """
+        The kd_tree_max is the maximum number of features in each tile when the features are distributed by a kd-tree.
+        If the user has specified a value for the kd_tree_max argument, use that value. Otherwise, use the
+        default value.
+        :return: a int
+        """
+        ktm_arg = self.args.kd_tree_max
+        kd_tree_max = ktm_arg if ktm_arg is not None and ktm_arg > 0 else self.DEFAULT_KD_TREE_MAX
+        print("kd tree max", kd_tree_max)
+        return kd_tree_max
+
     def create_tileset_from_geometries(self, feature_list, extension_name=None, kd_tree_max=500):
         """
         Create the 3DTiles tileset from the features.
@@ -107,7 +128,7 @@ class Tiler():
         """
         create_loa = self.args.loa is not None
         geometric_errors = self.args.geometric_error if hasattr(self.args, 'geometric_error') else [None, None, None]
-        tree = LodTree(feature_list, self.args.lod1, create_loa, self.args.loa, self.args.with_texture, kd_tree_max, geometric_errors)
+        tree = LodTree(feature_list, self.args.lod1, create_loa, self.args.loa, self.args.with_texture, self.get_kd_tree_max(), geometric_errors)
 
         feature_list.delete_objects_ref()
         self.create_output_directory()

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -21,7 +21,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False)
+                     split_surfaces=False, add_color=False, kd_tree_max=None)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -14,7 +14,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False)
+                     split_surfaces=False, add_color=False, kd_tree_max=None)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -8,7 +8,7 @@ from py3dtilers.GeojsonTiler.GeojsonTiler import GeojsonTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None])
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_objTiler.py
+++ b/tests/test_objTiler.py
@@ -8,7 +8,7 @@ from py3dtilers.ObjTiler.ObjTiler import ObjTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None])
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_tiler.py
+++ b/tests/test_tiler.py
@@ -10,7 +10,7 @@ from py3dtilers.Common.feature import Feature, FeatureList
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None])
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
 
 
 triangles = [[np.array([1843366, 5174473, 200], dtype=np.float32),
@@ -169,6 +169,24 @@ class Test_Tile(unittest.TestCase):
         tiler.args.geometric_error = [3, None, 200]
         tiler.args.lod1 = True
         tiler.args.loa = Path('tests/tiler_test_data/loa_polygons')
+
+        tileset = tiler.create_tileset_from_geometries(feature_list)
+
+        tileset.write_as_json(tiler.args.output_dir)
+
+    def test_kd_tree_max(self):
+        features = list()
+        for i in range(0, 3):
+            feature = Feature("kd_tree_" + str(i))
+            feature.geom.triangles.append(triangles)
+            feature.set_box()
+            features.append(feature)
+        feature_list = FeatureList(features)
+
+        tiler = Tiler()
+        tiler.args = get_default_namespace()
+        tiler.args.output_dir = Path('tests/tiler_test_data/generated_tilesets/kd_tree_max')
+        tiler.args.kd_tree_max = 1
 
         tileset = tiler.create_tileset_from_geometries(feature_list)
 

--- a/tests/test_tilesetReader.py
+++ b/tests/test_tilesetReader.py
@@ -9,7 +9,7 @@ from py3dtilers.TilesetReader.TilesetMerger import TilesetMerger
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None])
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
 
 
 class Test_Tile(unittest.TestCase):


### PR DESCRIPTION
New `--kd_tree_max` to set the maximum number of features in each tile when the features are distributed with a kd-tree. The flag must be followed by an integer.

Example:

```bash
citygml-tiler --type building --kd_tree_max 25  # Each tile while contain a maximum of 25 buildings 
```

Create a `DEFAULT_KD_TREE_MAX` equal to 500 and used when the user has not specified a value. When using the CityTiler with texture, this default value is divided by 20 to reduce the size of each image atlas (--> since there is one atlas by tile, if the tile contains to much features, the atlas will be too heavy).

[Issue](https://github.com/VCityTeam/py3dtilers/issues/76)