### PR TITLE
[GeojsonTiler] Allows to keep GeoJSON features properties in the Batch Table

### DIFF
--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -62,6 +62,12 @@ class GeojsonTiler(Tiler):
                                  help='When defined, the features from geojsons will be considered as rooftops.\
                                     We will thus substract the height from the coordinates to reach the floor.')
 
+        self.parser.add_argument('--keep_properties',
+                                 '-k',
+                                 dest='keep_properties',
+                                 action='store_true',
+                                 help='When defined, keep the properties of the GeoJSON features into the batch table.')
+
         self.parser.add_argument('--add_color',
                                  nargs='*',
                                  default=['NONE', 'numeric'],
@@ -178,7 +184,7 @@ class GeojsonTiler(Tiler):
                 feature.material_index = attribute_dict[value] + 1
         feature_list.add_materials(colors)
 
-    def from_geojson_directory(self, path, properties, is_roof=False, color_attribute=('NONE', 'numeric')):
+    def from_geojson_directory(self, path, properties, is_roof=False, color_attribute=('NONE', 'numeric'), keep_properties=False):
         """
         Create a tileset from a GeoJson file or a directory of GeoJson files
         :param path: a path to the file(s)
@@ -192,6 +198,9 @@ class GeojsonTiler(Tiler):
 
         if not color_attribute[0] == 'NONE':
             self.add_colors(objects, color_attribute)
+
+        if keep_properties:
+            [feature.set_batchtable_data(feature.feature_properties) for feature in objects]
 
         if(len(objects) == 0):
             print("No .geojson found in " + path)
@@ -217,7 +226,7 @@ def main():
                   'z', geojson_tiler.args.z]
 
     if(os.path.isdir(path) or Path(path).suffix == ".geojson" or Path(path).suffix == ".json"):
-        tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color)
+        tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color, geojson_tiler.args.keep_properties)
         if(tileset is not None):
             print("tileset in", geojson_tiler.get_output_dir())
             tileset.write_as_json(geojson_tiler.get_output_dir())

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -96,6 +96,14 @@ If you want to skip the precision, you can set _prec_ to '_NONE_':
 geojson-tiler --path <path> --prec NONE
 ```
 
+### Keep properties
+
+You can use the flag `-k` or `--keep_properties` to store the properties of the GeoJSON features in the batch table. All the properties of each feature will be stored.
+
+```bash
+geojson-tiler --path <path> --keep_properties
+```
+
 ## Shared Tiler features
 
 See [Common module features](../Common/README.md#common-tiler-features).

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -146,6 +146,18 @@ class Test_Tile(unittest.TestCase):
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
+    def test_keep_properties(self):
+        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
+        properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
+
+        geojson_tiler = GeojsonTiler()
+        geojson_tiler.args = get_default_namespace()
+        geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/keep_props")
+        geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_keep_props.obj')
+        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True, keep_properties=True)
+        if(tileset is not None):
+            tileset.write_as_json(geojson_tiler.args.output_dir)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
You can use the flag `-k` or `--keep_properties` to store the properties of the GeoJSON features in the batch table. All the properties of each feature will be stored.

```bash
geojson-tiler --path <path> --keep_properties
```

As shown below, this allows to visualize the properties of each building

![image](https://user-images.githubusercontent.com/32875283/179753633-99be1cf8-4b27-487d-9821-e87ff596a5a2.png)
