### PR TITLE
Common input mechanism for all the tilers

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -17,13 +17,8 @@ class CityTiler(Tiler):
 
     def __init__(self):
         super().__init__()
-
-        # adding positional arguments
-        self.parser.add_argument('--db_config_path',
-                                 nargs='*',
-                                 default=['py3dtilers/CityTiler/CityTilerDBConfig.yml'],
-                                 type=str,
-                                 help='Path(es) to the database configuration file(s)')
+        self.supported_extensions = ['.yml', '.YML']
+        self.default_input_path = 'py3dtilers/CityTiler/CityTilerDBConfig.yml'
 
         self.parser.add_argument('--type',
                                  nargs='?',
@@ -139,9 +134,6 @@ def main():
     city_tiler.parse_command_line()
     args = city_tiler.args
 
-    print('Connecting to database...')
-    cursor = open_data_base(args.db_config_path[0])
-
     if args.type == "building":
         objects_type = CityMBuildings
         if args.with_BTH:
@@ -153,6 +145,8 @@ def main():
     elif args.type == "bridge":
         objects_type = CityMBridges
 
+    print('Connecting to database...')
+    cursor = open_data_base(city_tiler.files[0])
     objects_type.set_cursor(cursor)
 
     tileset = city_tiler.from_3dcitydb(cursor, objects_type)

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -21,7 +21,7 @@ Copy and customize the [CityTilerDBConfigReference.yml](CityTilerDBConfigReferen
 You can then run the tiler by specifying the path to the _.yml_ configuration file:
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml
+citygml-tiler -i <path_to_file>/Config.yml
 ```
 
 The created tileset will be placed in a folder named `junk_<objects-type>` in the root directory. The name of the folder will be either `junk_buildings`, `junk_reliefs`, `junk_water_bodies` or `junk_bridges`, depending on the [objects type](#objects-type) (respectively `building`, `relief`, `water` and `bridge`).
@@ -53,25 +53,25 @@ By default, the tiler will treat the data as __buildings__. You can change the t
 * `building`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --type building
+citygml-tiler -i <path_to_file>/Config.yml --type building
 ```
 
 * `relief`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --type relief
+citygml-tiler -i <path_to_file>/Config.yml --type relief
 ```
 
 * `water`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --type water
+citygml-tiler -i <path_to_file>/Config.yml --type water
 ```
 
 * `bridge`
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --type bridge
+citygml-tiler -i <path_to_file>/Config.yml --type bridge
 ```
 
 ### Split surfaces
@@ -81,7 +81,7 @@ By default, the tiler merges the surfaces of the same CityObject into one `Featu
 To keep the surfaces split:
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --split_surfaces
+citygml-tiler -i <path_to_file>/Config.yml --split_surfaces
 ```
 
 ### Batch Table Hierarchy
@@ -91,7 +91,7 @@ The Batch table hierarchy is a [Batch Table](https://github.com/CesiumGS/3d-tile
 To create the BatchTableHierarchy extension:
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --with_BTH
+citygml-tiler -i <path_to_file>/Config.yml --with_BTH
 ```
 
 ### Color
@@ -99,13 +99,13 @@ citygml-tiler --db_config_path <path_to_file>/Config.yml --with_BTH
 When present, the `--add_color` flag adds a single colored material to each feature. The color of the material is determined by CityGML `objectclass` of each feature.  
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --add_color
+citygml-tiler -i <path_to_file>/Config.yml --add_color
 ```
 
 If you want to apply different colors on the surfaces of buildings (roof, wall and floor), use the `--split_surfaces` flag:
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --add_color --split_surfaces
+citygml-tiler -i <path_to_file>/Config.yml --add_color --split_surfaces
 ```
 
 The default colors are defined by a [JSON file](../Color/citytiler_config.json). If you want to change the colors used, update the file with the right color codes. (__See [Color module](../Color/README.md#color_dict) for more details__)
@@ -115,7 +115,7 @@ The default colors are defined by a [JSON file](../Color/citytiler_config.json).
 The flag `--ids` allows to keep only the selected CityObject(s). The flag must be followed by a list of CityGML IDs.
 
 ```bash
-citygml-tiler --db_config_path <path_to_file>/Config.yml --ids CityGML_ID_1 CityGML_ID_2
+citygml-tiler -i <path_to_file>/Config.yml --ids CityGML_ID_1 CityGML_ID_2
 ```
 
 ## CityTemporalTiler features
@@ -128,7 +128,7 @@ In order to run the CityTemporalTiler you will first need to obtain the so calle
 
 ```bash
 citygml-tiler-temporal                                         \
-  --db_config_path py3dtilers/CityTiler/CityTilerDBConfig2009.yml  \
+  -i py3dtilers/CityTiler/CityTilerDBConfig2009.yml  \
                    py3dtilers/CityTiler/CityTilerDBConfig2012.yml  \
                    py3dtilers/CityTiler/CityTilerDBConfig2015.yml  \
   --time_stamps 2009 2012 2015                                  \

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -21,8 +21,25 @@ graph TD;
 
 Some features may not have been implemented for some Tilers.
 
-### Output directory
+### Input
 
+| Tiler        |                    |
+| ------------ | ------------------ |
+| CityTiler    | :heavy_check_mark: |
+| ObjTiler     | :heavy_check_mark: |
+| GeojsonTiler | :heavy_check_mark: |
+| IfcTiler     | :heavy_check_mark: |
+| TilesetTiler | :heavy_check_mark: |
+
+The flags `-i`, `--paths`, `--path`, `--file_path` or `--db_config_file` allow to choose the input paths of the Tiler.
+
+The flag should be followed by paths to files or directories holding a set of files.
+
+```bash
+<tiler> -i <path>
+```
+
+### Output
 | Tiler        |                    |
 | ------------ | ------------------ |
 | CityTiler    | :heavy_check_mark: |

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -31,7 +31,7 @@ Some features may not have been implemented for some Tilers.
 | IfcTiler     | :heavy_check_mark: |
 | TilesetTiler | :heavy_check_mark: |
 
-The flags `-i`, `--paths`, `--path`, `--file_path` or `--db_config_file` allow to choose the input paths of the Tiler.
+The flag `-i` allows to choose the input paths of the Tiler.
 
 The flag should be followed by paths to files or directories holding a set of files.
 
@@ -39,7 +39,10 @@ The flag should be followed by paths to files or directories holding a set of fi
 <tiler> -i <path>
 ```
 
+Note that `--paths`, `--path`, `--file_path` and `--db_config_file` were kept as alternatives of `-i` to ensure retro-compability.
+
 ### Output
+
 | Tiler        |                    |
 | ------------ | ------------------ |
 | CityTiler    | :heavy_check_mark: |

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import sys
 
 from ..Common import LodTree, FromGeometryTreeToTileset, Groups
 from ..Color import ColorConfig
@@ -153,6 +154,11 @@ class Tiler():
         :param extension_name: an optional extension to add to the tileset
         :return: a TileSet
         """
+        if(len(feature_list) == 0):
+            print("No feature found in source")
+            sys.exit(1)
+        else:
+            print("Distribution of the", len(feature_list), "features...")
         groups = Groups(feature_list, self.args.loa, self.get_kd_tree_max()).get_groups_as_list()
         feature_list.delete_features_ref()
         return self.create_tileset_from_groups(groups, extension_name)

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -202,12 +202,6 @@ class GeojsonTiler(Tiler):
         if keep_properties:
             [feature.set_batchtable_data(feature.feature_properties) for feature in objects]
 
-        if(len(objects) == 0):
-            print("No .geojson found in " + path)
-            return None
-        else:
-            print(str(len(objects)) + " features parsed")
-
         return self.create_tileset_from_feature_list(objects)
 
 

--- a/py3dtilers/GeojsonTiler/GeojsonTiler.py
+++ b/py3dtilers/GeojsonTiler/GeojsonTiler.py
@@ -1,9 +1,5 @@
 import os
-import sys
-from os import listdir
 import json
-
-from pathlib import Path
 
 from .geojson import Geojson, Geojsons
 from .geojson_line import GeojsonLine
@@ -18,12 +14,7 @@ class GeojsonTiler(Tiler):
 
     def __init__(self):
         super().__init__()
-
-        # adding positional arguments
-        self.parser.add_argument('--path',
-                                 nargs=1,
-                                 type=str,
-                                 help='Path to a geojson file or a directory containing geojson files')
+        self.supported_extensions = ['.geojson', '.GEOJSON', 'json', '.JSON']
 
         self.parser.add_argument('--height',
                                  nargs='?',
@@ -82,12 +73,6 @@ class GeojsonTiler(Tiler):
         elif(len(self.args.add_color) == 1):
             self.args.add_color.append('numeric')
 
-        if(self.args.path is None):
-            print("Please provide a path to a directory "
-                  "containing some geojson files")
-            print("Exiting")
-            sys.exit(1)
-
     def get_output_dir(self):
         """
         Return the directory name for the tileset.
@@ -113,29 +98,17 @@ class GeojsonTiler(Tiler):
             'MultiLineString': GeojsonLine(id, feature_properties, feature_geometry, is_multi_geom=True)
         }[feature_geometry['type']]
 
-    def retrieve_geojsons(self, path):
+    def retrieve_geojsons(self):
         """
         Retrieve the GeoJson features from GeoJson file(s).
         Return a list of Geojson instances containing properties and a geometry.
-        :param path: a path to the file(s)
 
         :return: a list of Geojson instances.
         """
-        files = []
         features = []
 
-        if(os.path.isdir(path)):
-            geojson_dir = listdir(path)
-            for geojson_file in geojson_dir:
-                file_path = os.path.join(path, geojson_file)
-                if(os.path.isfile(file_path)):
-                    if(".geojson" in geojson_file or ".json" in geojson_file):
-                        files.append(file_path)
-        else:
-            files.append(path)
-
         # Reads and parse every features from the file(s)
-        for geojson_file in files:
+        for geojson_file in self.files:
             print("Reading " + str(geojson_file))
             with open(geojson_file) as f:
                 gjContent = json.load(f)
@@ -184,16 +157,14 @@ class GeojsonTiler(Tiler):
                 feature.material_index = attribute_dict[value] + 1
         feature_list.add_materials(colors)
 
-    def from_geojson_directory(self, path, properties, is_roof=False, color_attribute=('NONE', 'numeric'), keep_properties=False):
+    def from_geojson_directory(self, properties, is_roof=False, color_attribute=('NONE', 'numeric'), keep_properties=False):
         """
-        Create a tileset from a GeoJson file or a directory of GeoJson files
-        :param path: a path to the file(s)
+        Create a tileset from GeoJson files or a directories of GeoJson files
         :param properties: the names of the properties to read in the GeoJson file(s)
 
         :return: a tileset.
         """
-
-        features = self.retrieve_geojsons(path)
+        features = self.retrieve_geojsons()
         objects = Geojsons.parse_geojsons(features, properties, is_roof, color_attribute)
 
         if not color_attribute[0] == 'NONE':
@@ -213,19 +184,15 @@ def main():
     """
     geojson_tiler = GeojsonTiler()
     geojson_tiler.parse_command_line()
-    path = geojson_tiler.args.path[0]
     properties = ['height', geojson_tiler.args.height,
                   'width', geojson_tiler.args.width,
                   'prec', geojson_tiler.args.prec,
                   'z', geojson_tiler.args.z]
 
-    if(os.path.isdir(path) or Path(path).suffix == ".geojson" or Path(path).suffix == ".json"):
-        tileset = geojson_tiler.from_geojson_directory(path, properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color, geojson_tiler.args.keep_properties)
-        if(tileset is not None):
-            print("tileset in", geojson_tiler.get_output_dir())
-            tileset.write_as_json(geojson_tiler.get_output_dir())
-    else:
-        print(path, "is neither a geojson file or a directory. Please target geojson file or a directory containing geojson files.")
+    tileset = geojson_tiler.from_geojson_directory(properties, geojson_tiler.args.is_roof, geojson_tiler.args.add_color, geojson_tiler.args.keep_properties)
+    if(tileset is not None):
+        print("Writing tileset in", geojson_tiler.get_output_dir())
+        tileset.write_as_json(geojson_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -34,7 +34,7 @@ geojson-tiler -i ../../geojsons/
 It will read all .geojson and .json in the ___geojsons___ directory and parse them into 3DTiles.
 
 ```bash
-geojson-tiler -i ../../geojsons/file_1.geojson ../../geojsons/file_2.geojson
+geojson-tiler -i ../../file_1.geojson ../../geojsons
 ```
 
 It will read ___file_1.geojson___ and all .geojson and .json in the ___geojsons___ directory, and parse them into 3DTiles.

--- a/py3dtilers/GeojsonTiler/README.md
+++ b/py3dtilers/GeojsonTiler/README.md
@@ -17,28 +17,34 @@ See [installation notes](https://github.com/VCityTeam/py3dtilers/blob/master/REA
 
 ### Run the GeojsonTiler
 
-To execute the GeojsonTiler, use the flag `--path` followed by the path of a geojson file or a folder containing geojson files
+To execute the GeojsonTiler, use the flag `-i` followed by paths of Geojson files or directories containing Geojson files
 
 Example:
 
 ```bash
-geojson-tiler --path ../../geojsons/file.geojson
+geojson-tiler -i ../../geojsons/file.geojson
 ```
 
 It will read ___file.geojson___ and parse it into 3DTiles.
 
 ```bash
-geojson-tiler --path ../../geojsons/
+geojson-tiler -i ../../geojsons/
 ```
 
 It will read all .geojson and .json in the ___geojsons___ directory and parse them into 3DTiles.
+
+```bash
+geojson-tiler -i ../../geojsons/file_1.geojson ../../geojsons/file_2.geojson
+```
+
+It will read ___file_1.geojson___ and all .geojson and .json in the ___geojsons___ directory, and parse them into 3DTiles.
 
 ### Roofprint or footprint
 
 By default, the tiler considers that the polygons in the .geojson files are at the floor level. But sometimes, the coordinates can be at the roof level (especially for buildings). In this case, you can tell the tiler to consider the polygons as roofprints by adding the `--is_roof` flag. The tiler will substract the height of the feature from the coordinates to reach the floor level.
 
 ```bash
-geojson-tiler --path <path> --is_roof
+geojson-tiler -i <path> --is_roof
 ```
 
 ### Color
@@ -52,13 +58,13 @@ The flag takes 2 arguments: the name of the property and its type ('numeric' or 
 Example for numeric property:
 
 ```bash
-geojson-tiler --path <path> --add_color HEIGTH numeric
+geojson-tiler -i <path> --add_color HEIGTH numeric
 ```
 
 Example for semantic property:
 
 ```bash
-geojson-tiler --path <path> --add_color NATURE semantic
+geojson-tiler -i <path> --add_color NATURE semantic
 ```
 
 The default colors are defined by a [JSON file](../Color/default_config.json). If you want to change the colors used, update the file with the right color codes. (__See [Color module](../Color/README.md) for more details__)
@@ -81,19 +87,19 @@ It means the tiler will target the property 'HAUTEUR' to find the height, 'LARGE
 If the file doesn't contain those properties, you can change one or several property names to target in command line with `--height`, `--width` or `--prec`. If the features don't have a Z (2D features), a Z can be targeted with `--z`.
 
 ```bash
-geojson-tiler --path <path> --height HEIGHT_NAME --width WIDTH_NAME --prec PREC_NAME --z Z_NAME
+geojson-tiler -i <path> --height HEIGHT_NAME --width WIDTH_NAME --prec PREC_NAME --z Z_NAME
 ```
 
 You can set the height, the width or the Z to a default value (used for all features). The value must be an _int_ or a _float_:
 
 ```bash
-geojson-tiler --path <path> --height 10.5 --width 6.4 --z 100
+geojson-tiler -i <path> --height 10.5 --width 6.4 --z 100
 ```
 
 If you want to skip the precision, you can set _prec_ to '_NONE_':
 
 ```bash
-geojson-tiler --path <path> --prec NONE
+geojson-tiler -i <path> --prec NONE
 ```
 
 ### Keep properties
@@ -101,7 +107,7 @@ geojson-tiler --path <path> --prec NONE
 You can use the flag `-k` or `--keep_properties` to store the properties of the GeoJSON features in the batch table. All the properties of each feature will be stored.
 
 ```bash
-geojson-tiler --path <path> --keep_properties
+geojson-tiler -i <path> --keep_properties
 ```
 
 ## Shared Tiler features

--- a/py3dtilers/IfcTiler/README.md
+++ b/py3dtilers/IfcTiler/README.md
@@ -12,11 +12,14 @@ See [installation notes](https://github.com/VCityTeam/py3dtilers/blob/master/REA
 
 ### Run the IfcTiler
 
+To execute the IfcTiler, use the flag `-i` followed by paths of IFC files or directories containing IFC files
+
 ```bash
-(venv) ifc-tiler --file_path <path>
+(venv) ifc-tiler -i <path>
 ```
 
-\<path\> should point to a directory holding an IFC file.
+\<path\> should point to an IFC file or a directory holding IFC files.
+
 The resulting 3DTiles tileset will contain the ifc geometry, ordered by category :
 each tile will contain an IFC Object Type, that can be found in the batch table, along with its GUID
 
@@ -29,13 +32,13 @@ The `--grouped_by` flag allows to choose how to group the objects. The two are o
 Group by `IfcTypeObject`:
 
 ```bash
-ifc-tiler --file_path <path> --grouped_by IfcTypeObject
+ifc-tiler -i <path> --grouped_by IfcTypeObject
 ```
 
 Group by `IfcGroup`:
 
 ```bash
-ifc-tiler --file_path <path> --grouped_by IfcGroup
+ifc-tiler -i <path> --grouped_by IfcGroup
 ```
 
 ## Shared Tiler features

--- a/py3dtilers/ObjTiler/ObjTiler.py
+++ b/py3dtilers/ObjTiler/ObjTiler.py
@@ -1,7 +1,3 @@
-import os
-import sys
-from pathlib import Path
-
 from ..Common import Tiler
 from .obj import Objs
 
@@ -10,39 +6,23 @@ class ObjTiler(Tiler):
 
     def __init__(self):
         super().__init__()
-
-        # adding positional arguments
-        self.parser.add_argument('--paths',
-                                 nargs='*',
-                                 type=str,
-                                 help='path to the database configuration file')
+        self.supported_extensions = ['.obj', '.OBJ']
 
     def get_output_dir(self):
         """
         Return the directory name for the tileset.
         """
         if self.args.output_dir is None:
-            return os.path.join("obj_tilesets", Path(self.current_path).name)
+            return "obj_tilesets"
         else:
-            return os.path.join(self.args.output_dir, Path(self.current_path).name)
+            return self.args.output_dir
 
-    def parse_command_line(self):
-        super().parse_command_line()
-
-        if(self.args.paths is None):
-            print("Please provide a path to a directory "
-                  "containing some obj files or multiple directories")
-            print("Exiting")
-            sys.exit(1)
-
-    def from_obj_directory(self, path):
+    def from_obj_directory(self):
         """
         Create a tileset from OBJ files.
-        :param path: a path to a directory
-
         :return: a tileset.
         """
-        objects = Objs.retrieve_objs(path, self.args.with_texture)
+        objects = Objs.retrieve_objs(self.files, self.args.with_texture)
 
         return self.create_tileset_from_feature_list(objects)
 
@@ -59,16 +39,11 @@ def main():
     """
     obj_tiler = ObjTiler()
     obj_tiler.parse_command_line()
-    paths = obj_tiler.args.paths
 
-    for path in paths:
-        obj_tiler.current_path = path
-        if(os.path.isdir(path)):
-            print("Writing " + path)
-            tileset = obj_tiler.from_obj_directory(path)
-            if(tileset is not None):
-                print("tileset in", obj_tiler.get_output_dir())
-                tileset.write_as_json(obj_tiler.get_output_dir())
+    tileset = obj_tiler.from_obj_directory()
+    if(tileset is not None):
+        print("Writing tileset in", obj_tiler.get_output_dir())
+        tileset.write_as_json(obj_tiler.get_output_dir())
 
 
 if __name__ == '__main__':

--- a/py3dtilers/ObjTiler/ObjTiler.py
+++ b/py3dtilers/ObjTiler/ObjTiler.py
@@ -42,14 +42,7 @@ class ObjTiler(Tiler):
 
         :return: a tileset.
         """
-
         objects = Objs.retrieve_objs(path, self.args.with_texture)
-
-        if(len(objects) == 0):
-            print("No .obj found in " + path)
-            return None
-        else:
-            print(str(len(objects)) + " .obj parsed")
 
         return self.create_tileset_from_feature_list(objects)
 

--- a/py3dtilers/ObjTiler/README.md
+++ b/py3dtilers/ObjTiler/README.md
@@ -8,14 +8,16 @@ See [installation notes](https://github.com/VCityTeam/py3dtilers/blob/master/REA
 
 ### Run the ObjTiler
 
+To execute the ObjTiler, use the flag `-i` followed by paths of OBJ files or directories containing OBJ files
+
 ```bash
-(venv) obj-tiler --paths <directory_path>
+obj-tiler -i <path>
 ```
 
-where `directory_path` should point to directories holding a set of OBJ files.
+where `path` should point to an OBJ file or a directory holding a set of OBJ files.
 
 The resulting 3DTiles tileset will contain all of the converted OBJ that are
-located within this directory, using their filename as ID.
+located within the files, using their filename as ID.
 
 This command should produce a directory named `obj_tilesets`.
 

--- a/py3dtilers/ObjTiler/obj.py
+++ b/py3dtilers/ObjTiler/obj.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-from os import listdir
-
 import numpy as np
 import pywavefront
 
@@ -101,29 +98,27 @@ class Objs(FeatureList):
         super().__init__(objs)
 
     @staticmethod
-    def retrieve_objs(path, with_texture=False):
+    def retrieve_objs(files, with_texture=False):
         """
         Create Obj instance from OBJ file(s).
-        :param path: a path to a directory
+        :param files: paths to files
         :param with_texture: a boolean indicating if the textures should be read
 
         :return: a list of Obj.
         """
         objects = list()
-        obj_dir = listdir(path)
 
-        for obj_file in obj_dir:
-            if(os.path.isfile(os.path.join(path, obj_file))):
-                if(".obj" in obj_file):
-                    geom = pywavefront.Wavefront(os.path.join(path, obj_file), collect_faces=True)
-                    if(len(geom.vertices) == 0):
-                        continue
-                    for mesh in geom.mesh_list:
-                        # Get id from its name
-                        id = mesh.name
-                        obj = Obj(id)
-                        # Create geometry as expected from GLTF from an obj file
-                        if(obj.parse_geom(mesh, with_texture)):
-                            objects.append(obj)
+        for obj_file in files:
+            print("Reading " + str(obj_file))
+            geom = pywavefront.Wavefront(obj_file, collect_faces=True)
+            if(len(geom.vertices) == 0):
+                continue
+            for mesh in geom.mesh_list:
+                # Get id from its name
+                id = mesh.name
+                obj = Obj(id)
+                # Create geometry as expected from GLTF from an obj file
+                if(obj.parse_geom(mesh, with_texture)):
+                    objects.append(obj)
 
         return Objs(objects)

--- a/py3dtilers/TilesetReader/README.md
+++ b/py3dtilers/TilesetReader/README.md
@@ -13,15 +13,15 @@ See [installation notes](https://github.com/VCityTeam/py3dtilers/blob/master/REA
 ### Run the TilesetReader
 
 ```bash
-tileset-reader --paths <tileset_path>
+tileset-reader -i <tileset_path>
 ```
 
 Where `tileset_path` should point to the __root__ directory of a 3DTiles tileset.
 
-If several paths to tilesets are putted after the `--paths` flag, all the tilesets will be red and merged into a single one.
+If several paths to tilesets are put after the `-i` flag, all the tilesets will be red and merged into a single one.
 
 ```bash
-tileset-reader --paths <path1> <path2> <path3> ...
+tileset-reader -i <path1> <path2> <path3> ...
 ```
 
 All the triangles of the tiles will be loaded in memory to be able to transform them. If you don't want to transform the triangles, use the [`tileset-merger`](#tileset-merger) command instead.
@@ -41,7 +41,7 @@ The TilesetMerger can't translate, rescale or reproject the triangles.
 ### Run the TilesetMerger
 
 ```bash
-tileset-merger --paths <tileset_path_1> <tileset_path_2> <tileset_path_3> ...
+tileset-merger -i <tileset_path_1> <tileset_path_2> <tileset_path_3> ...
 ```
 
 Where `tileset_path_x` should point to the __root__ directory of a 3DTiles tileset.
@@ -51,5 +51,5 @@ The produced 3DTiles tileset will be in a directory named `tileset_merger_output
 Use `--output_dir`, `--out` or `-o` followed by the path of a directory to choose the output:
 
 ```bash
-tileset-merger --paths <tileset_path_1> <tileset_path_2> --output_dir ../merged_tileset
+tileset-merger -i <tileset_path_1> <tileset_path_2> --output_dir ../merged_tileset
 ```

--- a/py3dtilers/TilesetReader/TilesetMerger.py
+++ b/py3dtilers/TilesetReader/TilesetMerger.py
@@ -18,6 +18,7 @@ class TilesetMerger():
         """
         parser = argparse.ArgumentParser()
         parser.add_argument('--paths',
+                            '-i',
                             nargs='*',
                             type=str,
                             help='Paths to 3DTiles tilesets')

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -14,147 +14,147 @@ def get_default_namespace():
 class Test_Tile(unittest.TestCase):
 
     def test_basic_case(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/basic_case")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_properties_with_other_name(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
         properties = ['height', 'HEIGHT', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_2/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/properties_with_other_name")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_other_properties_name.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_default_height(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
         properties = ['height', '10', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_2/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/default_height")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_default_height.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_z(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
         properties = ['height', '10', 'prec', 'NONE', 'z', '300']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_2/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/z")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_z.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_no_height(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_2/')
         properties = ['height', 'HAUTEUR', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_2/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/no_height")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_no_height.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_add_color(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/add_color")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_color.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True, color_attribute=('HAUTEUR', 'numeric'))
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True, color_attribute=('HAUTEUR', 'numeric'))
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_create_loa(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/create_loa")
         geojson_tiler.args.loa = Path('tests/geojson_tiler_test_data/polygons/')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_create_lod1(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/create_lod1")
         geojson_tiler.args.lod1 = True
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_create_lod1_and_loa(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/create_lod1_and_loa")
         geojson_tiler.args.loa = Path('tests/geojson_tiler_test_data/polygons/')
         geojson_tiler.args.lod1 = True
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_line_string(self):
-        path = Path('tests/geojson_tiler_test_data/roads/line_string_road.geojson')
         properties = ['height', '1', 'width', '1', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/roads/line_string_road.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/line_string")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/road_line_string.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=False)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=False)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_multi_line_string(self):
-        path = Path('tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson')
         properties = ['height', '1', 'width', '1', 'prec', 'NONE', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/roads/multi_line_string_road.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/multi_line_string")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/road_multi_line_string.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=False)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=False)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 
     def test_keep_properties(self):
-        path = Path('tests/geojson_tiler_test_data/buildings/feature_1/')
         properties = ['height', 'HAUTEUR', 'prec', 'PREC_ALTI', 'z', 'NONE']
 
         geojson_tiler = GeojsonTiler()
+        geojson_tiler.files = [Path('tests/geojson_tiler_test_data/buildings/feature_1/oneBlock.geojson')]
         geojson_tiler.args = get_default_namespace()
         geojson_tiler.args.output_dir = Path("tests/geojson_tiler_test_data/generated_tilesets/keep_props")
         geojson_tiler.args.obj = Path('tests/geojson_tiler_test_data/generated_objs/block_keep_props.obj')
-        tileset = geojson_tiler.from_geojson_directory(path, properties, is_roof=True, keep_properties=True)
+        tileset = geojson_tiler.from_geojson_directory(properties, is_roof=True, keep_properties=True)
         if(tileset is not None):
             tileset.write_as_json(geojson_tiler.args.output_dir)
 

--- a/tests/test_ifcTiler.py
+++ b/tests/test_ifcTiler.py
@@ -14,12 +14,12 @@ def get_default_namespace():
 class Test_Tile(unittest.TestCase):
 
     def test_IFC4_case(self):
-        path = Path('tests/ifc_tiler_test_data/FZK.ifc')
         ifc_tiler = IfcTiler()
+        ifc_tiler.files = [Path('tests/ifc_tiler_test_data/FZK.ifc')]
         ifc_tiler.args = get_default_namespace()
         ifc_tiler.args.output_dir = Path("tests/ifc_tiler_test_data/generated_tilesets/")
 
-        tileset = ifc_tiler.from_ifc(path, ifc_tiler.args.grouped_by, with_BTH=False)
+        tileset = ifc_tiler.from_ifc(ifc_tiler.args.grouped_by, with_BTH=False)
         if(tileset is not None):
             tileset.write_as_json(ifc_tiler.args.output_dir)
 

--- a/tests/test_objTiler.py
+++ b/tests/test_objTiler.py
@@ -14,29 +14,27 @@ def get_default_namespace():
 class Test_Tile(unittest.TestCase):
 
     def test_basic_case(self):
-        path = Path('tests/obj_tiler_data/Cube')
         obj_tiler = ObjTiler()
-        obj_tiler.current_path = "basic_case"
+        obj_tiler.files = [Path('tests/obj_tiler_data/Cube/cube_1.obj'), Path('tests/obj_tiler_data/Cube/cube_2.obj')]
         obj_tiler.args = get_default_namespace()
-        obj_tiler.args.output_dir = Path("tests/obj_tiler_data/generated_tilesets/")
+        obj_tiler.args.output_dir = Path("tests/obj_tiler_data/generated_tilesets/basic_case")
 
-        tileset = obj_tiler.from_obj_directory(path)
+        tileset = obj_tiler.from_obj_directory()
         if(tileset is not None):
-            tileset.write_as_json(Path(obj_tiler.args.output_dir, obj_tiler.current_path))
+            tileset.write_as_json(Path(obj_tiler.args.output_dir))
 
     def test_texture(self):
-        path = Path('tests/obj_tiler_data/TexturedCube')
         obj_tiler = ObjTiler()
-        obj_tiler.current_path = "texture"
+        obj_tiler.files = [Path('tests/obj_tiler_data/TexturedCube/cube.obj')]
         obj_tiler.args = get_default_namespace()
-        obj_tiler.args.output_dir = Path("tests/obj_tiler_data/generated_tilesets/")
+        obj_tiler.args.output_dir = Path("tests/obj_tiler_data/generated_tilesets/texture")
         obj_tiler.args.offset = [1843397, 5173891, 300]  # Arbitrary offset to place the 3DTiles in Lyon city
         obj_tiler.args.with_texture = True
         obj_tiler.args.scale = 50
 
-        tileset = obj_tiler.from_obj_directory(path)
+        tileset = obj_tiler.from_obj_directory()
         if(tileset is not None):
-            tileset.write_as_json(Path(obj_tiler.args.output_dir, obj_tiler.current_path))
+            tileset.write_as_json(Path(obj_tiler.args.output_dir))
 
 
 if __name__ == '__main__':

--- a/tests/test_tilesetReader.py
+++ b/tests/test_tilesetReader.py
@@ -18,9 +18,9 @@ class Test_Tile(unittest.TestCase):
         tiler = TilesetTiler()
         tiler.args = get_default_namespace()
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/basic_case/")
-        paths = [Path("tests/tileset_reader_test_data/white_buildings/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 
@@ -28,9 +28,9 @@ class Test_Tile(unittest.TestCase):
         tiler = TilesetTiler()
         tiler.args = get_default_namespace()
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/merge/")
-        paths = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 
@@ -39,9 +39,9 @@ class Test_Tile(unittest.TestCase):
         tiler.args = get_default_namespace()
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/texture/")
         tiler.args.with_texture = True
-        paths = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 
@@ -51,9 +51,9 @@ class Test_Tile(unittest.TestCase):
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/transform/")
         tiler.args.offset = [0, 0, -200]
         tiler.args.scale = 1.2
-        paths = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 
@@ -62,9 +62,9 @@ class Test_Tile(unittest.TestCase):
         tiler.args = get_default_namespace()
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/obj/")
         tiler.args.obj = "tests/tileset_reader_test_data/generated_objs/output.obj"
-        paths = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings/"), Path("tests/tileset_reader_test_data/textured_cube/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 
@@ -73,9 +73,9 @@ class Test_Tile(unittest.TestCase):
         tiler.args = get_default_namespace()
         tiler.args.output_dir = Path("tests/tileset_reader_test_data/generated_tilesets/geometric_error/")
         tiler.args.geometric_error = [3, None, 100]
-        paths = [Path("tests/tileset_reader_test_data/white_buildings_with_lods/"), Path("tests/tileset_reader_test_data/textured_cube/")]
+        tiler.files = [Path("tests/tileset_reader_test_data/white_buildings_with_lods/"), Path("tests/tileset_reader_test_data/textured_cube/")]
 
-        tileset = tiler.read_and_merge_tilesets(paths)
+        tileset = tiler.read_and_merge_tilesets()
         tileset = tiler.transform_tileset(tileset)
         tileset.write_as_json(tiler.args.output_dir)
 


### PR DESCRIPTION
This PR introduce a common input mechanism shared by all the tilers.

The tilers now use the `-i` for the input. The flag should be followed by at least one path. Each path should point to a file or a directory holding a set of files.

Note that the old input flags (`--path`, `--paths`, `--db_config_file`, `--file_path`) were kept as alternatives of `-i` to ensure retro-compability.