### PR TITLE
Create texture levels of detail

### DIFF
--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -208,6 +208,34 @@ Two flags can be use to reduce the size of the images. The flag `--quality` can 
 
 _Note: if your texture images are too heavy, consider using [`--kd_tree_max` option](#kd-tree-max) to reduce the number of objects per tile._
 
+### Texture LODs
+
+| Tiler        |                    |
+| ------------ | ------------------ |
+| CityTiler    | :heavy_check_mark: |
+| ObjTiler     | :heavy_check_mark: |
+| GeojsonTiler | :x:                |
+| IfcTiler     | :x:                |
+| TilesetTiler | :x:                |
+
+The flag `--texture_lods` (or `--tl`) can be used to set the number of levels of detail that will be created for each textured tile. Each level of detail will be a tile with a less detailled image but the same geometry. The size of the images is reduced with a [Nearest Neighbor Resampling algorithm](https://clouard.users.greyc.fr/Pantheon/experiments/rescaling/index-en.html#nearest).
+
+```bash
+<tiler> <input> --texture_lods 4  # Create 4 additional tiles for each textured tile
+```
+
+The first additional level has downsize ratio of 3, meaning the image will be 3 times smaller than the original. Then each following level increment this ratio by 10.
+
+```mermaid
+graph TD;
+   LOD1[LOD1, ratio=33];
+   LOD2[LOD2, ratio=23];
+   LOD3[LOD3, ratio=13];
+   LOD4[LOD4, ratio=3];
+   Tile[Textured Tile]---LOD4---LOD3---LOD2---LOD1;
+
+```
+
 ### Geometric error
 
 | Tiler        |                    |

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -233,7 +233,6 @@ graph TD;
    LOD3[LOD3, ratio=13];
    LOD4[LOD4, ratio=3];
    Tile[Textured Tile]---LOD4---LOD3---LOD2---LOD1;
-
 ```
 
 ### Geometric error

--- a/py3dtilers/Common/geometry_node.py
+++ b/py3dtilers/Common/geometry_node.py
@@ -21,6 +21,7 @@ class GeometryNode():
         :param feature_list: an instance of FeatureList.
         :param geometric_error: the metric used to refine the node when visualizing the features.
         :param Boolean with_texture: if this node must keep the texture of the features or not.
+        :param int downsample_factor: the factor used to downsize the texture image
         """
         self.feature_list = feature_list
         self.child_nodes = list()

--- a/py3dtilers/Common/geometry_node.py
+++ b/py3dtilers/Common/geometry_node.py
@@ -16,7 +16,7 @@ class GeometryNode():
     # https://github.com/CesiumGS/3d-tiles/tree/main/specification#geometric-error
     DEFAULT_GEOMETRIC_ERROR = 1
 
-    def __init__(self, feature_list: 'FeatureList' = None, geometric_error=None, with_texture=False):
+    def __init__(self, feature_list: 'FeatureList' = None, geometric_error=None, with_texture=False, downsample_factor=1):
         """
         :param feature_list: an instance of FeatureList.
         :param geometric_error: the metric used to refine the node when visualizing the features.
@@ -26,6 +26,7 @@ class GeometryNode():
         self.child_nodes = list()
         self.with_texture = with_texture
         self.geometric_error = geometric_error if geometric_error is not None else self.DEFAULT_GEOMETRIC_ERROR
+        self.downsample_factor = downsample_factor
 
     def set_child_nodes(self, nodes: List['GeometryNode'] = list()):
         """

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -1,5 +1,6 @@
 from ..Common import GeometryTree, GeometryNode, Lod1Node, LoaNode
 from typing import TYPE_CHECKING
+import copy
 
 if TYPE_CHECKING:
     from ..Common import Groups
@@ -19,8 +20,14 @@ class LodTree(GeometryTree):
         root_nodes = list()
 
         for group in groups:
-            node = GeometryNode(group.feature_list, geometric_errors[0], with_texture)
+            node = GeometryNode(group.feature_list, 1, with_texture)
             root_node = node
+            factor = 3
+            for _ in range(0,4):
+                textured_node = GeometryNode(copy.deepcopy(group.feature_list), int(factor/3), with_texture, factor)
+                textured_node.add_child_node(root_node)
+                root_node = textured_node
+                factor += 10
             if create_lod1:
                 lod1_node = Lod1Node(node, geometric_errors[1])
                 lod1_node.add_child_node(root_node)

--- a/py3dtilers/Common/lod_tree.py
+++ b/py3dtilers/Common/lod_tree.py
@@ -11,7 +11,7 @@ class LodTree(GeometryTree):
     The LodTree contains the root node(s) of the LOD hierarchy and the centroid of the whole tileset
     """
 
-    def __init__(self, groups: 'Groups', create_lod1=False, create_loa=False, with_texture=False, geometric_errors=[None, None, None]):
+    def __init__(self, groups: 'Groups', create_lod1=False, create_loa=False, with_texture=False, geometric_errors=[None, None, None], texture_lods=0):
         """
         LodTree takes an instance of FeatureList (which contains a collection of Feature) and creates nodes.
         In order to reduce the number of .b3dm, it also distributes the features into a list of Group.
@@ -20,14 +20,15 @@ class LodTree(GeometryTree):
         root_nodes = list()
 
         for group in groups:
-            node = GeometryNode(group.feature_list, 1, with_texture)
+            node = GeometryNode(group.feature_list, geometric_errors[0], with_texture)
             root_node = node
-            factor = 3
-            for _ in range(0,4):
-                textured_node = GeometryNode(copy.deepcopy(group.feature_list), int(factor/3), with_texture, factor)
+            downsample_factor = 3
+            for _ in range(0, texture_lods):
+                geometric_error = (downsample_factor / 3) + geometric_errors[0] if geometric_errors[0] else downsample_factor / 3
+                textured_node = GeometryNode(copy.deepcopy(group.feature_list), geometric_error, with_texture, downsample_factor)
                 textured_node.add_child_node(root_node)
                 root_node = textured_node
-                factor += 10
+                downsample_factor += 10
             if create_lod1:
                 lod1_node = Lod1Node(node, geometric_errors[1])
                 lod1_node.add_child_node(root_node)

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -114,6 +114,14 @@ class Tiler():
                                  help='Set the maximum number of features in each tile when the features are distributed by a kd-tree.\
                                      The value must be an integer.')
 
+        self.parser.add_argument('--texture_lods',
+                                 '--tl',
+                                 nargs='?',
+                                 type=int,
+                                 default=0,
+                                 help='Set the number of levels of detail that will be created for each textured tile.\
+                                     Each level of detail will be a tile with a less detailled image but the same geometry.')
+
     def parse_command_line(self):
         self.args = self.parser.parse_args()
 
@@ -218,7 +226,7 @@ class Tiler():
         create_loa = self.args.loa is not None
         geometric_errors = self.args.geometric_error if hasattr(self.args, 'geometric_error') else [None, None, None]
 
-        tree = LodTree(groups, self.args.lod1, create_loa, self.args.with_texture, geometric_errors)
+        tree = LodTree(groups, self.args.lod1, create_loa, self.args.with_texture, geometric_errors, self.args.texture_lods)
 
         self.create_output_directory()
         return FromGeometryTreeToTileset.convert_to_tileset(tree, self.args, extension_name, self.get_output_dir())

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -129,7 +129,7 @@ class FromGeometryTreeToTileset():
         return tile
 
     @staticmethod
-    def __create_tile_content(feature_list: 'FeatureList', extension_name=None, with_texture=False, geometric_error=1):
+    def __create_tile_content(feature_list: 'FeatureList', extension_name=None, with_texture=False, downsample_factor=1):
         """
         :param pre_tile: an array containing features of a single tile
 
@@ -140,7 +140,7 @@ class FromGeometryTreeToTileset():
         materials = []
         seen_mat_indexes = dict()
         if with_texture:
-            tile_atlas = Atlas(feature_list, geometric_error)
+            tile_atlas = Atlas(feature_list, downsample_factor)
             materials = [GlTFMaterial(textureUri='./' + tile_atlas.id)]
         for feature in feature_list:
             mat_index = feature.material_index

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -97,7 +97,7 @@ class FromGeometryTreeToTileset():
         tile = Tile()
         tile.set_geometric_error(node.geometric_error)
 
-        content_b3dm = FromGeometryTreeToTileset.__create_tile_content(feature_list, extension_name, node.has_texture())
+        content_b3dm = FromGeometryTreeToTileset.__create_tile_content(feature_list, extension_name, node.has_texture(), node.downsample_factor)
         tile.set_content(content_b3dm)
         tile.set_content_uri('tiles/' + f'{FromGeometryTreeToTileset.tile_index}.b3dm')
         tile.write_content(output_dir)
@@ -129,7 +129,7 @@ class FromGeometryTreeToTileset():
         return tile
 
     @staticmethod
-    def __create_tile_content(feature_list: 'FeatureList', extension_name=None, with_texture=False):
+    def __create_tile_content(feature_list: 'FeatureList', extension_name=None, with_texture=False, geometric_error=1):
         """
         :param pre_tile: an array containing features of a single tile
 
@@ -140,7 +140,7 @@ class FromGeometryTreeToTileset():
         materials = []
         seen_mat_indexes = dict()
         if with_texture:
-            tile_atlas = Atlas(feature_list)
+            tile_atlas = Atlas(feature_list, geometric_error)
             materials = [GlTFMaterial(textureUri='./' + tile_atlas.id)]
         for feature in feature_list:
             mat_index = feature.material_index

--- a/py3dtilers/Texture/atlas.py
+++ b/py3dtilers/Texture/atlas.py
@@ -12,7 +12,7 @@ class Atlas():
     An Atlas contains the texture images of a tile.
     """
 
-    def __init__(self, feature_list):
+    def __init__(self, feature_list, downsample_factor=1):
         features_with_id_key = dict()
         textures_with_id_key = dict()
 
@@ -29,7 +29,7 @@ class Atlas():
 
         self.tile_number = atlasTree.get_tile_number()
 
-        self.id = atlasTree.createAtlasImage(features_with_id_key, self.tile_number)
+        self.id = atlasTree.createAtlasImage(features_with_id_key, self.tile_number, downsample_factor)
 
     def computeArea(self, size):
         """

--- a/py3dtilers/Texture/atlas_node.py
+++ b/py3dtilers/Texture/atlas_node.py
@@ -114,6 +114,7 @@ class Node(object):
                         in triangles[0] and the UV must be in
                         triangles[1]
         :param tile_number: the tile number
+        :param int downsample_factor: the factor used to downsize the image
         """
         atlasImg = Image.new(
             'RGB',
@@ -122,8 +123,8 @@ class Node(object):
 
         self.fillAtlasImage(atlasImg, features_with_id_key)
         atlas_id = 'ATLAS_' + str(tile_number) + Texture.format
-        
-        atlasImg = atlasImg.resize((int(atlasImg.width/downsample_factor), int(atlasImg.height/downsample_factor)))
+
+        atlasImg = atlasImg.resize((int(atlasImg.width / downsample_factor), int(atlasImg.height / downsample_factor)))
         atlasImg.save(Path(Texture.folder, 'tiles', atlas_id), quality=Texture.quality, compress_level=Texture.compress_level)
         return atlas_id
 

--- a/py3dtilers/Texture/atlas_node.py
+++ b/py3dtilers/Texture/atlas_node.py
@@ -107,7 +107,7 @@ class Node(object):
             self.child[0].insert(img, feature_id)
             return self
 
-    def createAtlasImage(self, features_with_id_key, tile_number):
+    def createAtlasImage(self, features_with_id_key, tile_number, downsample_factor=1):
         """
         :param features_with_id_key: a dictionnary, with feature_id as key,
                         and triangles as value. The triangles position must be
@@ -122,6 +122,8 @@ class Node(object):
 
         self.fillAtlasImage(atlasImg, features_with_id_key)
         atlas_id = 'ATLAS_' + str(tile_number) + Texture.format
+        
+        atlasImg = atlasImg.resize((int(atlasImg.width/downsample_factor), int(atlasImg.height/downsample_factor)))
         atlasImg.save(Path(Texture.folder, 'tiles', atlas_id), quality=Texture.quality, compress_level=Texture.compress_level)
         return atlas_id
 

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -21,7 +21,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False, kd_tree_max=None)
+                     split_surfaces=False, add_color=False, kd_tree_max=None, texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -171,6 +171,18 @@ class Test_Tile(unittest.TestCase):
 
         tileset.write_as_json(city_tiler.args.output_dir)
 
+    def test_building_texture_lods(self):
+
+        objects_type = CityMBuildings
+        city_tiler = CityTiler()
+        city_tiler.args = get_default_namespace()
+        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/building_texture_lods")
+        city_tiler.args.with_texture = True
+        city_tiler.args.texture_lods = 5
+        tileset = city_tiler.from_3dcitydb(self.cursor, objects_type)
+
+        tileset.write_as_json(city_tiler.args.output_dir)
+
     def test_relief_texture(self):
 
         objects_type = CityMReliefs

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -17,7 +17,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False, kd_tree_max=None, ids=[])
+                     split_surfaces=False, add_color=False, kd_tree_max=None, ids=[], texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -8,7 +8,8 @@ from py3dtilers.GeojsonTiler.GeojsonTiler import GeojsonTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
+                     texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_ifcTiler.py
+++ b/tests/test_ifcTiler.py
@@ -8,7 +8,7 @@ from py3dtilers.IfcTiler.IfcTiler import IfcTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, grouped_by='IfcTypeObject', scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None, texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_objTiler.py
+++ b/tests/test_objTiler.py
@@ -8,7 +8,8 @@ from py3dtilers.ObjTiler.ObjTiler import ObjTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
+                     texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):
@@ -31,6 +32,20 @@ class Test_Tile(unittest.TestCase):
         obj_tiler.args.offset = [1843397, 5173891, 300]  # Arbitrary offset to place the 3DTiles in Lyon city
         obj_tiler.args.with_texture = True
         obj_tiler.args.scale = 50
+
+        tileset = obj_tiler.from_obj_directory()
+        if(tileset is not None):
+            tileset.write_as_json(Path(obj_tiler.args.output_dir))
+
+    def test_texture_lods(self):
+        obj_tiler = ObjTiler()
+        obj_tiler.files = [Path('tests/obj_tiler_data/TexturedCube/cube.obj')]
+        obj_tiler.args = get_default_namespace()
+        obj_tiler.args.output_dir = Path("tests/obj_tiler_data/generated_tilesets/texture_lods")
+        obj_tiler.args.offset = [1843397, 5173891, 300]  # Arbitrary offset to place the 3DTiles in Lyon city
+        obj_tiler.args.with_texture = True
+        obj_tiler.args.scale = 50
+        obj_tiler.args.texture_lods = 5
 
         tileset = obj_tiler.from_obj_directory()
         if(tileset is not None):

--- a/tests/test_tiler.py
+++ b/tests/test_tiler.py
@@ -11,7 +11,8 @@ from py3dtilers.Texture import Texture
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
+                     texture_lods=0)
 
 
 triangles = [[np.array([1843366, 5174473, 200]),
@@ -235,6 +236,25 @@ class Test_Tile(unittest.TestCase):
         tiler.args.with_texture = True
         Texture.set_texture_quality(10)
         Texture.set_texture_format('jpeg')
+
+        tileset = tiler.create_tileset_from_feature_list(feature_list)
+
+        tileset.write_as_json(tiler.args.output_dir)
+
+    def test_texture_lods(self):
+        feature = Feature("texture_lods")
+        feature.geom.triangles.append(triangles)
+        feature.geom.triangles.append(uvs)
+        texture = Texture(Path('tests/tiler_test_data/texture.jpg'))
+        feature.set_texture(texture.get_cropped_texture_image(feature.geom.triangles[1]))
+        feature.set_box()
+        feature_list = FeatureList([feature])
+
+        tiler = Tiler()
+        tiler.args = get_default_namespace()
+        tiler.args.output_dir = Path('tests/tiler_test_data/generated_tilesets/texture_lods')
+        tiler.args.with_texture = True
+        tiler.args.texture_lods = 4
 
         tileset = tiler.create_tileset_from_feature_list(feature_list)
 

--- a/tests/test_tilesetReader.py
+++ b/tests/test_tilesetReader.py
@@ -9,7 +9,8 @@ from py3dtilers.TilesetReader.TilesetMerger import TilesetMerger
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
+                     texture_lods=0)
 
 
 class Test_Tile(unittest.TestCase):


### PR DESCRIPTION
The flag `--texture_lods` (or `--tl`) can be used to set the number of levels of detail that will be created for each textured tile. Each level of detail will be a tile with a less detailled image but the same geometry. The size of the images is reduced with a [Nearest Neighbor Resampling algorithm](https://clouard.users.greyc.fr/Pantheon/experiments/rescaling/index-en.html#nearest).

```bash
<tiler> <input> --texture_lods 4  # Create 4 additional tiles for each textured tile
```

The first additional level has downsize ratio of 3, meaning the image will be 3 times smaller than the original. Then each following level increment this ratio by 10.

```mermaid
graph TD;
   LOD1[LOD1, ratio=33];
   LOD2[LOD2, ratio=23];
   LOD3[LOD3, ratio=13];
   LOD4[LOD4, ratio=3];
   Tile[Textured Tile]---LOD4---LOD3---LOD2---LOD1;

```