### PR TITLE
Keep and exclude IDs in all tilers

### DIFF
--- a/py3dtilers/CityTiler/CityTiler.py
+++ b/py3dtilers/CityTiler/CityTiler.py
@@ -43,12 +43,6 @@ class CityTiler(Tiler):
                                  action='store_true',
                                  help='When defined, add colors to the features depending on their CityGML objectclass.')
 
-        self.parser.add_argument('--ids',
-                                 nargs='*',
-                                 default=[],
-                                 type=str,
-                                 help='If present, keep only the CityObjects which have their CityGML in the list.')
-
     def get_output_dir(self):
         """
         Return the directory name for the tileset.
@@ -110,7 +104,7 @@ class CityTiler(Tiler):
         :return: a tileset.
         """
         print('Retrieving city objects from database...')
-        cityobjects = CityMCityObjects.retrieve_objects(cursor, objects_type, citygml_ids=self.args.ids)
+        cityobjects = CityMCityObjects.retrieve_objects(cursor, objects_type)
         print(len(cityobjects), f'city objects of type \'{objects_type.__name__}\' found in the database.')
 
         if not cityobjects:

--- a/py3dtilers/CityTiler/README.md
+++ b/py3dtilers/CityTiler/README.md
@@ -112,10 +112,14 @@ The default colors are defined by a [JSON file](../Color/citytiler_config.json).
 
 ### ID filter
 
-The flag `--ids` allows to keep only the selected CityObject(s). The flag must be followed by a list of CityGML IDs.
+The flag `--keep_ids` and `--exclude_ids` allows to filter the CityObject(s). The flag must be followed by a list of __CityGML IDs__. See [ID filter](../Common/README.md#id-filter).
 
 ```bash
-citygml-tiler -i <path_to_file>/Config.yml --ids CityGML_ID_1 CityGML_ID_2
+citygml-tiler -i <path_to_file>/Config.yml --keep_ids CityGML_ID_1 CityGML_ID_2
+```
+
+```bash
+citygml-tiler -i <path_to_file>/Config.yml --exclude_ids CityGML_ID_1 CityGML_ID_2
 ```
 
 ## CityTemporalTiler features

--- a/py3dtilers/CityTiler/citym_bridge.py
+++ b/py3dtilers/CityTiler/citym_bridge.py
@@ -24,13 +24,11 @@ class CityMBridges(CityMCityObjects):
         super().__init__(features)
 
     @staticmethod
-    def sql_query_objects(bridges, citygml_ids=list()):
+    def sql_query_objects(bridges):
         """
         :param bridges: a list of CityMbridge type object that should be sought
                         in the database. When this list is empty all the objects
                         encountered in the database are returned.
-        :param citygml_ids: a list of cityGML IDs. If the list isn't empty, we keep
-                        only the objects of the list
 
         :return: a string containing the right SQL query that should be executed.
         """
@@ -40,9 +38,6 @@ class CityMBridges(CityMCityObjects):
             query = "SELECT bridge.id, cityobject.gmlid " + \
                     "FROM citydb.bridge JOIN citydb.cityobject ON bridge.id=cityobject.id " + \
                     "WHERE bridge.id=bridge.bridge_root_id"
-            if len(citygml_ids) > 0:
-                citygml_ids_as_string = "('" + "', '".join(citygml_ids) + "')"
-                query += " AND cityobject.gmlid IN " + citygml_ids_as_string
         else:
             bridge_gmlids = [n.get_gml_id() for n in bridges]
             bridge_gmlids_as_string = "('" + "', '".join(bridge_gmlids) + "')"

--- a/py3dtilers/CityTiler/citym_building.py
+++ b/py3dtilers/CityTiler/citym_building.py
@@ -53,13 +53,11 @@ class CityMBuildings(CityMCityObjects):
         return cls.with_bth
 
     @staticmethod
-    def sql_query_objects(buildings, citygml_ids=list()):
+    def sql_query_objects(buildings):
         """
         :param buildings: a list of CityMBuilding type object that should be sought
                         in the database. When this list is empty all the objects
                         encountered in the database are returned.
-        :param citygml_ids: a list of cityGML IDs. If the list isn't empty, we keep
-                        only the objects of the list
 
         :return: a string containing the right SQL query that should be executed.
         """
@@ -69,9 +67,6 @@ class CityMBuildings(CityMCityObjects):
             query = "SELECT building.id, cityobject.gmlid " + \
                     "FROM citydb.building JOIN citydb.cityobject ON building.id=cityobject.id " + \
                     "WHERE building.id=building.building_root_id"
-            if len(citygml_ids) > 0:
-                citygml_ids_as_string = "('" + "', '".join(citygml_ids) + "')"
-                query += " AND cityobject.gmlid IN " + citygml_ids_as_string
         else:
             building_gmlids = [n.get_gml_id() for n in buildings]
             building_gmlids_as_string = "('" + "', '".join(building_gmlids) + "')"

--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -129,6 +129,14 @@ class CityMCityObjects(FeatureList):
             texture_dict[feature.get_id()] = uri_dict[uri].get_cropped_texture_image(feature.geom.triangles[1])
         return texture_dict
 
+    def filter(self, filter_function):
+        """
+        Filter the features. Keep only those accepted by the filter function.
+        The filter function must take an ID as input.
+        :param filter_function: a function
+        """
+        self.features = list(filter(lambda f: filter_function(f.get_gml_id()), self.features))
+
     @staticmethod
     def set_cursor(cursor):
         """
@@ -156,7 +164,7 @@ class CityMCityObjects(FeatureList):
         pass
 
     @staticmethod
-    def retrieve_objects(cursor, objects_type, cityobjects=list(), citygml_ids=list()):
+    def retrieve_objects(cursor, objects_type, cityobjects=list()):
         """
         :param cursor: a database access cursor.
         :param objects_type: a class name among CityMCityObject derived classes.
@@ -166,9 +174,6 @@ class CityMCityObjects(FeatureList):
                         sought in the database. When this list is empty all
                         the objects encountered in the database are returned.
 
-        :param citygml_ids: a list of cityGML IDs. If the list isn't empty, we keep only
-                        the city objects of the list
-
         :return: an objects_type type object containing the objects that were retrieved
                 in the 3DCityDB database, each object being decorated with its database
                 identifier as well as its 3D bounding box (as retrieved in the database).
@@ -177,7 +182,7 @@ class CityMCityObjects(FeatureList):
             no_input = True
         else:
             no_input = False
-        cursor.execute(objects_type.sql_query_objects(cityobjects, citygml_ids))
+        cursor.execute(objects_type.sql_query_objects(cityobjects))
 
         if no_input:
             result_objects = objects_type()

--- a/py3dtilers/CityTiler/citym_relief.py
+++ b/py3dtilers/CityTiler/citym_relief.py
@@ -39,13 +39,11 @@ class CityMReliefs(CityMCityObjects):
         super().__init__(features)
 
     @staticmethod
-    def sql_query_objects(reliefs, citygml_ids=list()):
+    def sql_query_objects(reliefs):
         """
         :param reliefs: a list of CityMRelief type object that should be sought
                         in the database. When this list is empty all the objects
                         encountered in the database are returned.
-        :param citygml_ids: a list of cityGML IDs. If the list isn't empty, we keep
-                        only the objects of the list
 
         :return: a string containing the right sql query that should be executed.
         """
@@ -54,9 +52,6 @@ class CityMReliefs(CityMCityObjects):
             # we can find in the database:
             query = "SELECT relief_feature.id, cityobject.gmlid " + \
                     "FROM citydb.relief_feature JOIN citydb.cityobject ON relief_feature.id=cityobject.id"
-            if len(citygml_ids) > 0:
-                citygml_ids_as_string = "('" + "', '".join(citygml_ids) + "')"
-                query += " AND cityobject.gmlid IN " + citygml_ids_as_string
 
         else:
             relief_gmlids = [n.get_gml_id() for n in reliefs]

--- a/py3dtilers/CityTiler/citym_waterbody.py
+++ b/py3dtilers/CityTiler/citym_waterbody.py
@@ -39,7 +39,7 @@ class CityMWaterBodies(CityMCityObjects):
         super().__init__(features)
 
     @staticmethod
-    def sql_query_objects(waterbodies, citygml_ids=list()):
+    def sql_query_objects(waterbodies):
         """
         :param waterbodies: a list of CityMWaterBody type object that should be sought
                         in the database. When this list is empty all the objects
@@ -54,9 +54,6 @@ class CityMWaterBodies(CityMCityObjects):
             # we can find in the database:
             query = "SELECT waterbody.id, cityobject.gmlid " + \
                     "FROM citydb.waterbody JOIN citydb.cityobject ON waterbody.id=cityobject.id"
-            if len(citygml_ids) > 0:
-                citygml_ids_as_string = "('" + "', '".join(citygml_ids) + "')"
-                query += " AND cityobject.gmlid IN " + citygml_ids_as_string
         else:
             waterbody_gmlids = [n.get_gml_id() for n in waterbodies]
             waterbody_gmlids_as_string = "('" + "', '".join(waterbody_gmlids) + "')"

--- a/py3dtilers/Common/README.md
+++ b/py3dtilers/Common/README.md
@@ -283,6 +283,30 @@ When using the CityTiler [with texture](#with-texture), the default maximum of f
 <tiler> <input> --kd_tree_max 25  # Each tile will contain a maximum of 25 features
 ```
 
+### ID filter
+
+| Tiler        |                    |
+| ------------ | ------------------ |
+| CityTiler    | :heavy_check_mark: |
+| ObjTiler     | :heavy_check_mark: |
+| GeojsonTiler | :heavy_check_mark: |
+| IfcTiler     | :x: |
+| TilesetTiler | :heavy_check_mark: |
+
+The flag `--keep_ids` and `--exclude_ids` allows to filter the features. The flag must be followed by a list of IDs.
+
+`--keep_ids` keeps **only** the features which have their ID in the list.
+
+```bash
+<tiler> <input> --keep_ids id_1 id_2  # Keep only the features with those IDs
+```
+
+`--exclude_ids` **exclude** the features which have their ID in the list.
+
+```bash
+<tiler> <input> --exclude_ids id_1 id_2  # Exclude the features with those IDs
+```
+
 ## Developper notes
 
 ## [feature](feature.py)

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -337,6 +337,14 @@ class FeatureList(object):
             features_with_geom.extend(feature.get_geom(user_arguments, self, material_indexes))
         self.set_features(features_with_geom)
 
+    def filter(self, filter_function):
+        """
+        Filter the features. Keep only those accepted by the filter function.
+        The filter function must take an ID as input.
+        :param filter_function: a function
+        """
+        self.features = list(filter(lambda f: filter_function(f.get_id()), self.features))
+
     @classmethod
     def set_color_config(cls, config_path):
         """

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -227,11 +227,10 @@ class Tiler():
                 feature_list.filter(lambda id: id in self.args.keep_ids)
             if len(self.args.exclude_ids) > 0:
                 feature_list.filter(lambda id: id not in self.args.exclude_ids)
-            print(len(feature_list), "feature(s) after filter")
             if len(feature_list) == 0:
                 print("No feature left, exiting")
                 sys.exit(1)
-            print("Distribution of the", len(feature_list), "features...")
+            print("Distribution of the", len(feature_list), "feature(s)...")
         groups = Groups(feature_list, self.args.loa, self.get_kd_tree_max()).get_groups_as_list()
         feature_list.delete_features_ref()
         return self.create_tileset_from_groups(groups, extension_name)

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -122,6 +122,18 @@ class Tiler():
                                  help='Set the number of levels of detail that will be created for each textured tile.\
                                      Each level of detail will be a tile with a less detailled image but the same geometry.')
 
+        self.parser.add_argument('--keep_ids',
+                                 nargs='*',
+                                 default=[],
+                                 type=str,
+                                 help='If present, keep only the features which have their ID in the list.')
+
+        self.parser.add_argument('--exclude_ids',
+                                 nargs='*',
+                                 default=[],
+                                 type=str,
+                                 help='If present, exlude the features which have their ID in the list.')
+
     def parse_command_line(self):
         self.args = self.parser.parse_args()
 
@@ -211,6 +223,14 @@ class Tiler():
             print("No feature found in source")
             sys.exit(1)
         else:
+            if len(self.args.keep_ids) > 0:
+                feature_list.filter(lambda id: id in self.args.keep_ids)
+            if len(self.args.exclude_ids) > 0:
+                feature_list.filter(lambda id: id not in self.args.exclude_ids)
+            print(len(feature_list), "feature(s) after filter")
+            if len(feature_list) == 0:
+                print("No feature left, exiting")
+                sys.exit(1)
             print("Distribution of the", len(feature_list), "features...")
         groups = Groups(feature_list, self.args.loa, self.get_kd_tree_max()).get_groups_as_list()
         feature_list.delete_features_ref()

--- a/tests/test_cityTemporalTiler.py
+++ b/tests/test_cityTemporalTiler.py
@@ -21,7 +21,8 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False, kd_tree_max=None, texture_lods=0)
+                     split_surfaces=False, add_color=False, kd_tree_max=None, texture_lods=0,
+                     keep_ids=[], exclude_ids=[])
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_cityTiler.py
+++ b/tests/test_cityTiler.py
@@ -17,7 +17,8 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None],
-                     split_surfaces=False, add_color=False, kd_tree_max=None, ids=[], texture_lods=0)
+                     split_surfaces=False, add_color=False, kd_tree_max=None, ids=[], texture_lods=0,
+                     keep_ids=[], exclude_ids=[])
 
 
 class Test_Tile(unittest.TestCase):
@@ -226,46 +227,46 @@ class Test_Tile(unittest.TestCase):
 
         tileset.write_as_json(city_tiler.args.output_dir)
 
-    def test_building_filter_id(self):
+    def test_building_keep_id(self):
 
         objects_type = CityMBuildings
         city_tiler = CityTiler()
         city_tiler.args = get_default_namespace()
-        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/building_filter_id")
-        city_tiler.args.ids = ["BU_69381AS107"]
+        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/building_keep_id")
+        city_tiler.args.keep_ids = ["BU_69381AS107"]
         tileset = city_tiler.from_3dcitydb(self.cursor, objects_type)
 
         tileset.write_as_json(city_tiler.args.output_dir)
 
-    def test_relief_filter_id(self):
+    def test_relief_keep_id(self):
 
         objects_type = CityMReliefs
         city_tiler = CityTiler()
         city_tiler.args = get_default_namespace()
-        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/relief_filter_id")
-        city_tiler.args.ids = ["TIN_8184c814-97b6-4d26-a6f2-03ef4bd6e65d"]
+        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/relief_keep_id")
+        city_tiler.args.keep_ids = ["TIN_8184c814-97b6-4d26-a6f2-03ef4bd6e65d"]
         tileset = city_tiler.from_3dcitydb(self.cursor, objects_type)
 
         tileset.write_as_json(city_tiler.args.output_dir)
 
-    def test_waterbody_filter_id(self):
+    def test_waterbody_keep_id(self):
 
         objects_type = CityMWaterBodies
         city_tiler = CityTiler()
         city_tiler.args = get_default_namespace()
-        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/waterbody_filter_id")
-        city_tiler.args.ids = ["a47bd1e2-f63a-450f-b0d4-4ce25798966d"]
+        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/waterbody_keep_id")
+        city_tiler.args.keep_ids = ["a47bd1e2-f63a-450f-b0d4-4ce25798966d"]
         tileset = city_tiler.from_3dcitydb(self.cursor, objects_type)
 
         tileset.write_as_json(city_tiler.args.output_dir)
 
-    def test_bridge_filter_id(self):
+    def test_bridge_keep_id(self):
 
         objects_type = CityMBridges
         city_tiler = CityTiler()
         city_tiler.args = get_default_namespace()
-        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/bridge_filter_id")
-        city_tiler.args.ids = ["ID_58ee6b1f-48eb-4907-9c7a-679354adc73f"]
+        city_tiler.args.output_dir = Path("tests/city_tiler_test_data/generated_tilesets/bridge_keep_id")
+        city_tiler.args.keep_ids = ["ID_58ee6b1f-48eb-4907-9c7a-679354adc73f"]
         tileset = city_tiler.from_3dcitydb(self.cursor, objects_type)
 
         tileset.write_as_json(city_tiler.args.output_dir)

--- a/tests/test_geojsonTiler.py
+++ b/tests/test_geojsonTiler.py
@@ -9,7 +9,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
-                     texture_lods=0)
+                     texture_lods=0, keep_ids=[], exclude_ids=[])
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_ifcTiler.py
+++ b/tests/test_ifcTiler.py
@@ -8,7 +8,7 @@ from py3dtilers.IfcTiler.IfcTiler import IfcTiler
 def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, grouped_by='IfcTypeObject', scale=1,
-                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None, texture_lods=0)
+                     output_dir=None, geometric_error=[None, None, None], kd_tree_max=None, texture_lods=0, keep_ids=[], exclude_ids=[])
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_objTiler.py
+++ b/tests/test_objTiler.py
@@ -9,7 +9,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
-                     texture_lods=0)
+                     texture_lods=0, keep_ids=[], exclude_ids=[])
 
 
 class Test_Tile(unittest.TestCase):

--- a/tests/test_tiler.py
+++ b/tests/test_tiler.py
@@ -12,7 +12,7 @@ def get_default_namespace():
     return Namespace(obj=None, loa=None, lod1=False, crs_in='EPSG:3946',
                      crs_out='EPSG:3946', offset=[0, 0, 0], with_texture=False, scale=1,
                      output_dir=None, geometric_error=[None, None, None], kd_tree_max=None,
-                     texture_lods=0)
+                     texture_lods=0, keep_ids=[], exclude_ids=[])
 
 
 triangles = [[np.array([1843366, 5174473, 200]),
@@ -255,6 +255,42 @@ class Test_Tile(unittest.TestCase):
         tiler.args.output_dir = Path('tests/tiler_test_data/generated_tilesets/texture_lods')
         tiler.args.with_texture = True
         tiler.args.texture_lods = 4
+
+        tileset = tiler.create_tileset_from_feature_list(feature_list)
+
+        tileset.write_as_json(tiler.args.output_dir)
+
+    def test_keep_ids(self):
+        features = list()
+        for i in range(0, 3):
+            feature = Feature("id_" + str(i))
+            feature.geom.triangles.append(triangles)
+            feature.set_box()
+            features.append(feature)
+        feature_list = FeatureList(features)
+
+        tiler = Tiler()
+        tiler.args = get_default_namespace()
+        tiler.args.output_dir = Path('tests/tiler_test_data/generated_tilesets/keep_ids')
+        tiler.args.keep_ids = ["id_1"]
+
+        tileset = tiler.create_tileset_from_feature_list(feature_list)
+
+        tileset.write_as_json(tiler.args.output_dir)
+
+    def test_exclude_ids(self):
+        features = list()
+        for i in range(0, 3):
+            feature = Feature("id_" + str(i))
+            feature.geom.triangles.append(triangles)
+            feature.set_box()
+            features.append(feature)
+        feature_list = FeatureList(features)
+
+        tiler = Tiler()
+        tiler.args = get_default_namespace()
+        tiler.args.output_dir = Path('tests/tiler_test_data/generated_tilesets/exclude_ids')
+        tiler.args.exclude_ids = ["id_1"]
 
         tileset = tiler.create_tileset_from_feature_list(feature_list)
 


### PR DESCRIPTION
- New IDs filter mechanism working for all tilers (except the IFC tiler).
- Allows to keep or exclude features
- The flag `--ids` of the CityTiler is deleted. With the CityTiler, we use the CityGML ID (instead of the database ID) to filter.

Usage:

The flag `--keep_ids` and `--exclude_ids` allows to filter the features. The flag must be followed by a list of IDs.

`--keep_ids` keeps **only** the features which have their ID in the list.

```bash
<tiler> <input> --keep_ids id_1 id_2  # Keep only the features with those IDs
```

`--exclude_ids` **exclude** the features which have their ID in the list.

```bash
<tiler> <input> --exclude_ids id_1 id_2  # Exclude the features with those IDs
```