### PR TITLE
Add CityGML surface type in batch table

### DIFF
--- a/py3dtilers/CityTiler/citym_cityobject.py
+++ b/py3dtilers/CityTiler/citym_cityobject.py
@@ -37,10 +37,7 @@ class CityMCityObject(Feature):
         Set the gml id of this object. The gml id is kept into the batch table.
         :param gml_id: the id of the object
         """
-        batch_table_data = {
-            'gml_id': gml_id
-        }
-        super().set_batchtable_data(batch_table_data)
+        super().add_batchtable_data('gml_id', gml_id)
 
     def get_gml_id(self):
         """
@@ -81,13 +78,15 @@ class CityMCityObject(Feature):
                         texture_uri = t[3]
                         cityobject.texture_uri = texture_uri
                         associated_data = [uv_as_string]
-                    elif user_arguments.add_color:
+                    else:
                         surface_classname = t[2]
-                        if surface_classname not in material_indexes:
-                            material = feature_list.get_color_config().get_color_by_key(surface_classname)
-                            material_indexes[surface_classname] = len(feature_list.materials)
-                            feature_list.add_materials([material])
-                        cityobject.material_index = material_indexes[surface_classname]
+                        cityobject.add_batchtable_data('citygml::surface_type', surface_classname)
+                        if user_arguments.add_color:
+                            if surface_classname not in material_indexes:
+                                material = feature_list.get_color_config().get_color_by_key(surface_classname)
+                                material_indexes[surface_classname] = len(feature_list.materials)
+                                feature_list.add_materials([material])
+                            cityobject.material_index = material_indexes[surface_classname]
 
                     cityobject.geom = TriangleSoup.from_wkb_multipolygon(geom_as_string, associated_data)
                     if len(cityobject.geom.triangles[0]) > 0:

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -18,7 +18,7 @@ class Feature(object):
         self.geom = TriangleSoup()
 
         # Optional application specific data to be added to the batch table for this object
-        self.batchtable_data = None
+        self.batchtable_data = {}
 
         # A Bounding Volume Box object
         self.box = None
@@ -58,6 +58,14 @@ class Feature(object):
         :return: a dictionary
         """
         return self.batchtable_data
+
+    def add_batchtable_data(self, key, data):
+        """
+        Add an attribute to the batch table data of this feature.
+        :param key: the name of the attribute
+        :param data: the data
+        """
+        self.batchtable_data[key] = data
 
     def get_centroid(self):
         """

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -181,7 +181,7 @@ class FromGeometryTreeToTileset():
 
         # if there is application specific data associated with the features, add it to the batch table
         features_data = [feature.get_batchtable_data() for feature in feature_list]
-        if not all([feature_data is None for feature_data in features_data]):
+        if all([feature_data for feature_data in features_data]):
             # Construct a set of all possible batch table keys
             bt_keys = set()
             for key_subset in [feature_data.keys() for feature_data in features_data]:


### PR DESCRIPTION
When creating 3DTiles from CityGML data with split surfaces (`--split_surfaces`), save the surface classname as an attribute in the bath table

- new method to add data in the batch table data of a feature
- save surface classname as `citygml::surface_type` in the batch table