### PR TITLE
Fix incorrect py3DTilers versions in __init__.py

### DIFF
--- a/py3dtilers/__init__.py
+++ b/py3dtilers/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'


### PR DESCRIPTION
Fix py3DTilers version in __init__.py file.

Issue link : https://github.com/VCityTeam/py3dtilers/issues/152