### PR TITLE
Replace parse_args function by parse_known_args

### DIFF
--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -135,7 +135,7 @@ class Tiler():
                                  help='If present, exlude the features which have their ID in the list.')
 
     def parse_command_line(self):
-        self.args = self.parser.parse_args()
+        self.args, _ = self.parser.parse_known_args()
 
         if self.args.paths is None or len(self.args.paths) == 0:
             if self.default_input_path is not None:

--- a/py3dtilers/TilesetReader/TilesetMerger.py
+++ b/py3dtilers/TilesetReader/TilesetMerger.py
@@ -28,7 +28,7 @@ class TilesetMerger():
                             nargs='?',
                             type=str,
                             help='Output directory of the tileset.')
-        args = parser.parse_args()
+        args, _ = parser.parse_known_args()
         if args.output_dir is not None:
             self.output_path = Path(args.output_dir)
         return args.paths


### PR DESCRIPTION
I fix the issue by replacing `parse_args` function by `parse_known_args` ; https://github.com/VCityTeam/py3dtilers/issues/155.