### PR TITLE
Mesh reprojection changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         pytest
     - stage: "Markdown link checks"
       language: node_js
-      node_js: 14
+      node_js: 16
       script:
         - npm install --global remark-cli remark-validate-links
         - remark -u validate-links .

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -296,7 +296,7 @@ class FeatureList(object):
             feature.set_triangles(new_geom)
             feature.set_box()
 
-    def change_crs(self, transformer):
+    def change_crs(self, transformer, offset):
         """
         Project the features into another CRS
         :param transformer: the transformer used to change the crs
@@ -306,7 +306,7 @@ class FeatureList(object):
             for triangle in feature.get_geom_as_triangles():
                 new_position = []
                 for point in triangle:
-                    new_point = transformer.transform(point[0], point[1], point[2])
+                    new_point = transformer.transform((point + offset)[0], (point + offset)[1], (point + offset)[2])
                     new_position.append(np.array(new_point))
                 new_geom.append(new_position)
             feature.set_triangles(new_geom)

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -296,7 +296,7 @@ class FeatureList(object):
             feature.set_triangles(new_geom)
             feature.set_box()
 
-    def change_crs(self, transformer, offset = np.array([0, 0, 0])):
+    def change_crs(self, transformer, offset=np.array([0, 0, 0])):
         """
         Project the features into another CRS
         :param transformer: the transformer used to change the crs

--- a/py3dtilers/Common/feature.py
+++ b/py3dtilers/Common/feature.py
@@ -296,7 +296,7 @@ class FeatureList(object):
             feature.set_triangles(new_geom)
             feature.set_box()
 
-    def change_crs(self, transformer, offset):
+    def change_crs(self, transformer, offset = np.array([0, 0, 0])):
         """
         Project the features into another CRS
         :param transformer: the transformer used to change the crs

--- a/py3dtilers/Common/tiler.py
+++ b/py3dtilers/Common/tiler.py
@@ -50,7 +50,7 @@ class Tiler():
                                  nargs='?',
                                  type=float,
                                  help='Scale features by the input factor.')
-        
+
         self.parser.add_argument('--height_mult',
                                  nargs='?',
                                  type=float,
@@ -73,7 +73,7 @@ class Tiler():
                                  dest='with_texture',
                                  action='store_true',
                                  help='Adds texture to 3DTiles when defined')
-        
+
         self.parser.add_argument('--no_normals',
                                  dest='no_normals',
                                  action='store_true',

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -62,6 +62,7 @@ class FromGeometryTreeToTileset():
         if hasattr(user_args, 'height_mult') and user_args.height_mult:
             for feature_list in node.get_features():
                 feature_list.height_mult_features(user_args.height_mult)
+            tree_centroid = np.array([tree_centroid[0], tree_centroid[1], tree_centroid[2] * user_args.height_mult])
 
         if hasattr(user_args, 'scale') and user_args.scale:
             for feature_list in node.get_features():

--- a/py3dtilers/Common/tileset_creation.py
+++ b/py3dtilers/Common/tileset_creation.py
@@ -66,20 +66,18 @@ class FromGeometryTreeToTileset():
             for feature_list in node.get_features():
                 feature_list.scale_features(user_args.scale, tree_centroid)
 
-        centroid = node.feature_list.get_centroid()
-        offset = np.array([0, 0, 0]) if user_args.offset[0] == 'centroid' else centroid + np.array(user_args.offset)
+        offset = np.array([0, 0, 0]) if user_args.offset[0] == 'centroid' else np.array(user_args.offset)
 
         if not user_args.crs_in == user_args.crs_out:
             transformer = Transformer.from_crs(user_args.crs_in, user_args.crs_out)
-            tree_centroid = np.array(transformer.transform(tree_centroid[0], tree_centroid[1], tree_centroid[2]))
-            offset = np.array(transformer.transform(offset[0], offset[1], offset[2]))
+            tree_centroid = np.array(transformer.transform((tree_centroid + offset)[0], (tree_centroid + offset)[1], (tree_centroid + offset)[2]))
             for feature_list in node.get_features():
-                feature_list.change_crs(transformer)
+                feature_list.change_crs(transformer, offset)
 
         distance = node.feature_list.get_centroid() - tree_centroid
 
         for feature_list in node.get_features():
-            feature_list.translate_features(-feature_list.get_centroid())
+            feature_list.translate_features(-offset)
 
         if user_args.obj is not None:
             for leaf in node.get_leaves():


### PR DESCRIPTION
There are two important changes here that I think are necessary:
1. I think we should first add offset to coordinates and then do a transform. Existing code does it differently: it separately transforms an offset and vertices. Depending on the projection, you might get different results.
2. In tileset_creation on line 70 I am not adding centroid value. In OBJ meshes that I have (generated in Pix4d) all coordinates in the mesh can be converted to projection coordinates by adding offset values. If this changes causes issues with other datasets, we can implement this as an option on crs reprojection.