### PR TITLE
POT texture

### DIFF
--- a/py3dtilers/Texture/atlas.py
+++ b/py3dtilers/Texture/atlas.py
@@ -71,8 +71,6 @@ class Atlas():
         while node_root is None:
             node_root = Node(rect)
             axis = it % 2
-            axisX = 1 - axis
-            axisY = 1 - (1 - axis)
             for key, image in textures_sorted:
                 node_root = node_root.insert(image, key)
                 if node_root is None:
@@ -81,8 +79,8 @@ class Atlas():
                     rect = Rectangle(
                         0,
                         0,
-                        int(rect.get_width() + rect.get_width() * 0.5 * axisX),
-                        int(rect.get_height() + rect.get_height() * 0.5 * axisY)
+                        int(rect.get_width() + rect.get_width() * (1 - axis)),
+                        int(rect.get_height() + rect.get_height() * axis)
                     )
                     it += 1
                     break

--- a/py3dtilers/Texture/atlas.py
+++ b/py3dtilers/Texture/atlas.py
@@ -65,7 +65,7 @@ class Atlas():
         # where this does not work, since this creates a square.
         sizeOfAtlas = self.multipleOf2(np.sqrt(surfaceAtlas))
 
-        rect = Rectangle(0, 0, (sizeOfAtlas // 2) + 1, (sizeOfAtlas // 2) + 1)
+        rect = Rectangle(0, 0, sizeOfAtlas, sizeOfAtlas)
         node_root = None
         it = 0
         while node_root is None:

--- a/py3dtilers/Texture/atlas_node.py
+++ b/py3dtilers/Texture/atlas_node.py
@@ -124,7 +124,10 @@ class Node(object):
         self.fillAtlasImage(atlasImg, features_with_id_key)
         atlas_id = 'ATLAS_' + str(tile_number) + Texture.format
 
-        atlasImg = atlasImg.resize((int(atlasImg.width / downsample_factor), int(atlasImg.height / downsample_factor)))
+        if downsample_factor != 1:
+            width = 1 << (int(atlasImg.width / downsample_factor) - 1).bit_length()
+            height = 1 << (int(atlasImg.height / downsample_factor) - 1).bit_length()
+            atlasImg = atlasImg.resize((width, height))
         atlasImg.save(Path(Texture.folder, 'tiles', atlas_id), quality=Texture.quality, compress_level=Texture.compress_level)
         return atlas_id
 


### PR DESCRIPTION
Create texture atlases whose size is a power of 2

Texture images are slightly larger on disk (~1.07 time larger than before) but will be rendered more quickly (see #170 and [NPOT textures](https://www.soft8soft.com/wiki/index.php/NPOT_Textures#:~:text=An%20NPOT%20texture%20is%20a,Power%2DOf%2DTwo))