### PR TITLE
Support for Python 3.8, 3.10 & 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 dist: focal
 
+branches:
+  only:
+    - master
+
 addons:
-  postgresql: "12"
+  postgresql: '12'
   apt:
     update: true
     packages:
@@ -9,20 +13,39 @@ addons:
 
 jobs:
   include:
-    - stage: tests
+    - stage: Test Python 3.8
       language: python
-      python: "3.9"
+      python: '3.8'
       install:
-          ### Proceed with the install of py3dtilers per se.
-          # The extra flag installs the dev dependencies, refer to e.g.
-          # https://stackoverflow.com/questions/30239152/specify-extras-require-with-pip-install-e
         - pip install -e .[dev,prod]
-        - python -c 'import ifcopenshell'  # Just to make sure
       script:
-      - |
-        flake8 .
-        pytest
-    - stage: "Markdown link checks"
+        - pytest
+
+    - stage: Test Python 3.9
+      language: python
+      python: '3.9'
+      install:
+        - pip install -e .[dev,prod]
+      script:
+        - pytest
+
+    - stage: Test Python 3.10
+      language: python
+      python: '3.10'
+      install:
+        - pip install -e .[dev,prod]
+      script:
+        - pytest
+
+    - stage: Test Python 3.11
+      language: python
+      python: '3.11'
+      install:
+        - pip install -e .[dev,prod]
+      script:
+        - pytest
+
+    - stage: Markdown link checks
       language: node_js
       node_js: 16
       script:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,7 +7,6 @@ Py3DTilers is distributed under the GNU Lesser General Public License Version 2.
 
 | Package         |    License    |
 | --------------- | ------------- |
-| [Networkx](https://networkx.org/documentation/stable/index.html)| [BSD](https://networkx.org/documentation/stable/license.html) | |
 | [numpy](https://numpy.org/doc/stable/index.html) | [BSD](https://numpy.org/doc/stable/license.html) |
 | [psycopg2](https://www.psycopg.org/docs/) | [LGPL v3.0](http://www.gnu.org/licenses/lgpl-3.0-standalone.html) |
 | [pyproj](https://pyproj4.github.io/pyproj/stable/) | [MIT](https://en.wikipedia.org/wiki/MIT_License) |
@@ -22,41 +21,6 @@ Py3DTilers is distributed under the GNU Lesser General Public License Version 2.
 | [sortedcollections](https://github.com/grantjenks/python-sortedcollections) | [Apache v2.0](https://github.com/grantjenks/python-sortedcollections/blob/master/LICENSE) |
 
 # Py3DTilers dependencies and their associated respective licenses : expanded version
-
-## __Networkx__
-Copyright (C) 2004-2020, NetworkX Developers  
-Aric Hagberg <hagberg@lanl.gov>  
-Dan Schult <dschult@colgate.edu>  
-Pieter Swart <swart@lanl.gov>  
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-    copyright notice, this list of conditions and the following
-    disclaimer in the documentation and/or other materials provided
-    with the distribution.
-
-    * Neither the name of the NetworkX Developers nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## __numpy__
 Copyright (c) 2005-2021, NumPy Developers.  

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://app.travis-ci.com/VCityTeam/py3dtilers.svg?branch=master)](https://app.travis-ci.com/VCityTeam/py3dtilers)
 [![Documentation Status](https://readthedocs.org/projects/ansicolortags/badge/?version=latest)](https://vcityteam.github.io/py3dtilers/py3dtilers/index.html)
 
+[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-3818/) [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-3918/) [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-31013/) [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3116/)
+
 Py3DTilers is a Python tool and library allowing to build [`3D Tiles`](https://github.com/AnalyticalGraphicsInc/3d-tiles) tilesets out of various geometrical formats e.g. [OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file), [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON), [IFC](https://en.wikipedia.org/wiki/Industry_Foundation_Classes) or [CityGML](https://en.wikipedia.org/wiki/CityGML) through [3dCityDB databases](https://3dcitydb-docs.readthedocs.io/en/release-v4.2.3/).
 
 Py3DTilers uses [`py3dtiles` python library](https://github.com/VCityTeam/py3dtiles/tree/Tiler) (forked from [Oslandia's py3dtiles](https://gitlab.com/Oslandia/py3dtiles)) for its in memory representation of tilesets.
@@ -26,9 +28,7 @@ Find 3D Tiles created with Py3DTilers in [**this online demo**](https://py3dtile
 
 ## Installation from sources
 
-Py3DTilers works with **Python 3.9**.
-
-You can use a lower version if you don't plan to work with the IfcTiler. Then, comment the line of the [IfcOpenShell in the setup.py](./setup.py#L23).
+See [supported Python versions](#python-3dtiles-tilers)
 
 ### For Unix
 
@@ -36,7 +36,7 @@ Install binary sub-dependencies with your platform package installer e.g. for Ub
 
 ```bash
 apt-get install -y libpq-dev       # required usage of psycopg2 within py3dtilers
-apt-get install python3.9 python3.9-dev         # Python3 version must be 3.9
+apt-get install python3 python3-dev
 ```
 
 Install Py3DTilers in a safe [python virtual environment](https://docs.python.org/3/tutorial/venv.html) (not mandatory yet quite recommended)
@@ -45,21 +45,19 @@ Install Py3DTilers in a safe [python virtual environment](https://docs.python.or
 apt-get install virtualenv git
 git clone https://github.com/VCityTeam/py3dtilers
 cd py3dtilers
-virtualenv -p python3.9 venv
+virtualenv -p python3 venv
 . venv/bin/activate
 (venv)$ pip install -e .
 ```
 
 ### For Windows
 
-Install **python3.9**.
-
 In order to install Py3DTilers from sources use:
 
 ```bash
 git clone https://github.com/VCityTeam/py3dtilers
 cd py3dtilers
-python3.9 -m venv venv
+python3 -m venv venv
 . venv/Scripts/activate
 (venv)$ pip install -e .
 ```

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ prod_requirements = (
     'testing.postgresql @ git+https://github.com/tk0miya/testing.postgresql'
 )
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
@@ -67,10 +68,15 @@ setup(
     author='Université de Lyon',
     author_email='contact@liris.cnrs.fr',
     license='Apache License Version 2.0',
+    python_requires=">=3.8,<=3.11",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.5',
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
+
     ],
     packages=find_packages(),
     install_requires=requirements,
@@ -93,9 +99,9 @@ setup(
                  ),
                 ('py3dtilers/Color',
                  ['py3dtilers/Color/default_config.json']
-                ),
+                 ),
                 ('py3dtilers/Color',
                  ['py3dtilers/Color/citytiler_config.json']
-                )],
+                 )],
     zip_safe=False  # zip packaging conflicts with Numba cache (#25)
 )

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,14 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = (
     'wheel',
-    'networkx',
-    'numpy <1.21,>=1.17',
+    'numpy',
     'psycopg2',
     'pyproj',
     'pywavefront',
     'pyyaml',
-    'scipy ==1.9.3',
+    'scipy==1.9.3',
     'shapely',
-    'alphashape <=1.3.1',
+    'alphashape',
     'py3dtiles @ git+https://github.com/VCityTeam/py3dtiles@Tiler',
     'earclip @ git+https://github.com/lionfish0/earclip',
     'Pillow',


### PR DESCRIPTION
Clean requirements to support at least Python 3.9 and 3.10. Yet to test with >=3.11, not sure we should support <3.8

TODO:

- [x] 3.9
- [x] 3.10
- [x] 3.8
- [x] 3.11
- [x] 3.12 (tested but not supported)
- [x] Run CI with different Python versions
- [x] Update installation doc