### PR TITLE
chore: update contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,7 +13,8 @@
 
 - Vincent Jaillot ([Ciril Group](https://www.cirilgroup.com/en/))
 - Clément COLIN ([Carl Software/Berger Levrault](https://www.carl-software.com/))
-- Christophe TRIQUET ([CNES](https://cnes.fr/en))
+- Christophe TRIQUET ([CS GROUP](https://www.csgroup.eu/en/))
+- Fabien PUECH ([CS GROUP](https://www.csgroup.eu/en/))
 - Augustin TRANCART ([Oslandia](https://oslandia.com/en/))
 - charly-perspectives
 - andreiveselov


### PR DESCRIPTION
That PR updates the contributors file to include those who contributed to the previous PR https://github.com/VCityTeam/py3dtilers/pull/180.